### PR TITLE
Add Quest List Window

### DIFF
--- a/VanillaPlus/Features/QuestListWindow/QuestEntryNode.cs
+++ b/VanillaPlus/Features/QuestListWindow/QuestEntryNode.cs
@@ -3,6 +3,7 @@ using Dalamud.Game.Addon.Events;
 using FFXIVClientStructs.FFXIV.Client.UI;
 using FFXIVClientStructs.FFXIV.Client.UI.Agent;
 using FFXIVClientStructs.FFXIV.Component.GUI;
+using KamiToolKit.Classes;
 using KamiToolKit.Nodes;
 
 namespace VanillaPlus.Features.QuestListWindow;
@@ -13,6 +14,8 @@ public unsafe class QuestEntryNode : SimpleComponentNode {
     private readonly IconImageNode questIconNode;
     private readonly TextNode questNameTextNode;
     private readonly TextNode questLevelTextNode;
+    private readonly TextNode issuerNameTextNode;
+    private readonly TextNode distanceTextNode;
 
     public QuestEntryNode() {
         hoveredBackgroundNode = new SimpleNineGridNode {
@@ -36,18 +39,38 @@ public unsafe class QuestEntryNode : SimpleComponentNode {
 
         questNameTextNode = new TextNode {
             NodeId = 4,
-            AlignmentType = AlignmentType.Left,
+            AlignmentType = AlignmentType.BottomLeft,
             TextFlags = TextFlags.Ellipsis,
+            FontSize = 13,
             IsVisible = true,
         };
         System.NativeController.AttachNode(questNameTextNode, this);
 
-        questLevelTextNode = new TextNode {
+        issuerNameTextNode = new TextNode {
             NodeId = 5,
-            AlignmentType = AlignmentType.Left,
+            AlignmentType = AlignmentType.TopLeft,
+            TextColor = ColorHelper.GetColor(2),
+            TextFlags = TextFlags.Ellipsis,
+            FontSize = 12,
+            IsVisible = true,
+        };
+        System.NativeController.AttachNode(issuerNameTextNode, this);
+        
+        questLevelTextNode = new TextNode {
+            NodeId = 6,
+            AlignmentType = AlignmentType.BottomLeft,
+            FontSize = 13,
             IsVisible = true,
         };
         System.NativeController.AttachNode(questLevelTextNode, this);
+
+        distanceTextNode = new TextNode {
+            NodeId = 7,
+            AlignmentType = AlignmentType.TopRight,
+            TextColor = ColorHelper.GetColor(2),
+            IsVisible = true,
+        };
+        System.NativeController.AttachNode(distanceTextNode, this);
         
         CollisionNode.AddEvent(AddonEventType.MouseOver, _ => {
             IsHovered = true;
@@ -57,9 +80,9 @@ public unsafe class QuestEntryNode : SimpleComponentNode {
             if (QuestInfo is null) return;
 
             var agentMap = AgentMap.Instance();
-            agentMap->OpenMap(agentMap->CurrentMapId, agentMap->CurrentTerritoryId);
+            agentMap->OpenMap(agentMap->CurrentMapId, agentMap->CurrentTerritoryId, QuestInfo.Name.ToString());
             agentMap->FlagMarkerCount = 0;
-            agentMap->SetFlagMapMarker(agentMap->CurrentTerritoryId, agentMap->CurrentMapId, QuestInfo.MarkerData.Position, QuestInfo.MarkerData.IconId);
+            agentMap->SetFlagMapMarker(agentMap->CurrentTerritoryId, agentMap->CurrentMapId, QuestInfo.Position, QuestInfo.IconId);
             RaptureAtkModule.Instance()->FocusAddon(agentMap->AddonId);
         });
         
@@ -82,6 +105,7 @@ public unsafe class QuestEntryNode : SimpleComponentNode {
             
             questIconNode.IconId = value.IconId;
             questNameTextNode.ReadOnlySeString = value.Name;
+            issuerNameTextNode.ReadOnlySeString = value.IssuerName;
         }
     }
 
@@ -98,10 +122,19 @@ public unsafe class QuestEntryNode : SimpleComponentNode {
         questIconNode.Size = new Vector2(Height, Height);
         questIconNode.Position = Vector2.Zero;
 
-        questLevelTextNode.Size = new Vector2(45.0f, Height);
+        questLevelTextNode.Size = new Vector2(45.0f, Height / 2.0f);
         questLevelTextNode.Position = new Vector2(Width - questLevelTextNode.Width - 4.0f, 0.0f);
         
-        questNameTextNode.Size = new Vector2(Width - questIconNode.Width - questLevelTextNode.Width - 8.0f, Height);
+        questNameTextNode.Size = new Vector2(Width - questIconNode.Width - questLevelTextNode.Width - 8.0f, Height / 2.0f);
         questNameTextNode.Position = new Vector2(questIconNode.Width + 4.0f, 0.0f);
+
+        issuerNameTextNode.Size = new Vector2(Width - questIconNode.Width - questLevelTextNode.Width - 16.0f, Height / 2.0f);
+        issuerNameTextNode.Position = new Vector2(questIconNode.Width + 12.0f, Height / 2.0f);
+
+        distanceTextNode.Size = questLevelTextNode.Size;
+        distanceTextNode.Position = new Vector2(Width - questLevelTextNode.Width - 4.0f, Height / 2.0f);
     }
+
+    public void Update()
+        => distanceTextNode.String = $"{QuestInfo.Distance:F1} y";
 }

--- a/VanillaPlus/Features/QuestListWindow/QuestEntryNode.cs
+++ b/VanillaPlus/Features/QuestListWindow/QuestEntryNode.cs
@@ -1,0 +1,107 @@
+﻿using System.Numerics;
+using Dalamud.Game.Addon.Events;
+using FFXIVClientStructs.FFXIV.Client.UI;
+using FFXIVClientStructs.FFXIV.Client.UI.Agent;
+using FFXIVClientStructs.FFXIV.Component.GUI;
+using KamiToolKit.Nodes;
+
+namespace VanillaPlus.Features.QuestListWindow;
+
+public unsafe class QuestEntryNode : SimpleComponentNode {
+
+    private readonly NineGridNode hoveredBackgroundNode;
+    private readonly IconImageNode questIconNode;
+    private readonly TextNode questNameTextNode;
+    private readonly TextNode questLevelTextNode;
+
+    public QuestEntryNode() {
+        hoveredBackgroundNode = new SimpleNineGridNode {
+            NodeId = 2,
+            TexturePath = "ui/uld/ListItemA.tex",
+            TextureCoordinates = new Vector2(0.0f, 22.0f),
+            TextureSize = new Vector2(64.0f, 22.0f),
+            TopOffset = 6,
+            BottomOffset = 6,
+            LeftOffset = 16,
+            RightOffset = 1,
+            IsVisible = false,
+        };
+        System.NativeController.AttachNode(hoveredBackgroundNode, this);
+        
+        questIconNode = new IconImageNode {
+            NodeId = 3,
+            IsVisible = true,
+        };
+        System.NativeController.AttachNode(questIconNode, this);
+
+        questNameTextNode = new TextNode {
+            NodeId = 4,
+            AlignmentType = AlignmentType.Left,
+            TextFlags = TextFlags.Ellipsis,
+            IsVisible = true,
+        };
+        System.NativeController.AttachNode(questNameTextNode, this);
+
+        questLevelTextNode = new TextNode {
+            NodeId = 5,
+            AlignmentType = AlignmentType.Left,
+            IsVisible = true,
+        };
+        System.NativeController.AttachNode(questLevelTextNode, this);
+        
+        CollisionNode.AddEvent(AddonEventType.MouseOver, _ => {
+            IsHovered = true;
+        });
+        
+        CollisionNode.AddEvent(AddonEventType.MouseClick, _ => {
+            if (QuestInfo is null) return;
+
+            var agentMap = AgentMap.Instance();
+            agentMap->OpenMap(agentMap->CurrentMapId, agentMap->CurrentTerritoryId);
+            agentMap->FlagMarkerCount = 0;
+            agentMap->SetFlagMapMarker(agentMap->CurrentTerritoryId, agentMap->CurrentMapId, QuestInfo.MarkerData.Position, QuestInfo.MarkerData.IconId);
+            RaptureAtkModule.Instance()->FocusAddon(agentMap->AddonId);
+        });
+        
+        CollisionNode.AddEvent(AddonEventType.MouseOut, _ => {
+            IsHovered = false;
+        });
+    }
+
+    public required QuestInfo QuestInfo {
+        get;
+        set {
+            field = value;
+
+            if (value.Level > 0) {
+                questLevelTextNode.String = $"Lv. {value.Level}";
+            }
+            else {
+                questNameTextNode.Width = Width - questIconNode.Width - 4.0f;
+            }
+            
+            questIconNode.IconId = value.IconId;
+            questNameTextNode.ReadOnlySeString = value.Name;
+        }
+    }
+
+    public bool IsHovered {
+        get => hoveredBackgroundNode.IsVisible;
+        set => hoveredBackgroundNode.IsVisible = value;
+    }
+
+    protected override void OnSizeChanged() {
+        base.OnSizeChanged();
+
+        hoveredBackgroundNode.Size = Size;
+        
+        questIconNode.Size = new Vector2(Height, Height);
+        questIconNode.Position = Vector2.Zero;
+
+        questLevelTextNode.Size = new Vector2(45.0f, Height);
+        questLevelTextNode.Position = new Vector2(Width - questLevelTextNode.Width - 4.0f, 0.0f);
+        
+        questNameTextNode.Size = new Vector2(Width - questIconNode.Width - questLevelTextNode.Width - 8.0f, Height);
+        questNameTextNode.Position = new Vector2(questIconNode.Width + 4.0f, 0.0f);
+    }
+}

--- a/VanillaPlus/Features/QuestListWindow/QuestInfo.cs
+++ b/VanillaPlus/Features/QuestListWindow/QuestInfo.cs
@@ -1,16 +1,43 @@
-﻿using System.Text.RegularExpressions;
-using FFXIVClientStructs.FFXIV.Client.Game.UI;
+﻿using System;
+using System.Numerics;
+using System.Text.RegularExpressions;
 using Lumina.Text.ReadOnly;
 
 namespace VanillaPlus.Features.QuestListWindow;
 
-public record QuestInfo(uint IconId, ReadOnlySeString Name, ushort Level, MapMarkerData MarkerData) {
+public class QuestInfo : IEquatable<QuestInfo> {
+    public uint ObjectiveId { get; init; }
+    public uint IconId { get; init; }
+    public ReadOnlySeString Name { get; init; }
+    public ushort Level { get; init; }
+    public Vector3 Position { get; init; }
+    public ReadOnlySeString IssuerName { get; init; }
+    
+    public float Distance => Vector3.Distance(Services.ClientState.LocalPlayer?.Position ?? Vector3.Zero, Position);
+    
     public bool IsRegexMatch(string searchString) {
         const RegexOptions regexOptions = RegexOptions.CultureInvariant | RegexOptions.IgnoreCase;
     
         if (Regex.IsMatch(Name.ToString(), searchString, regexOptions)) return true;
         if (Regex.IsMatch(Level.ToString(), searchString, regexOptions)) return true;
+        if (Regex.IsMatch(IssuerName.ToString(), searchString, regexOptions)) return true;
 
         return false;
     }
+
+    public bool Equals(QuestInfo? other) {
+        if (other is null) return false;
+        if (ReferenceEquals(this, other)) return true;
+        return ObjectiveId == other.ObjectiveId;
+    }
+
+    public override bool Equals(object? obj) {
+        if (obj is null) return false;
+        if (ReferenceEquals(this, obj)) return true;
+        if (obj.GetType() != GetType()) return false;
+        return Equals((QuestInfo) obj);
+    }
+
+    public override int GetHashCode()
+        => HashCode.Combine(ObjectiveId);
 }

--- a/VanillaPlus/Features/QuestListWindow/QuestInfo.cs
+++ b/VanillaPlus/Features/QuestListWindow/QuestInfo.cs
@@ -1,0 +1,16 @@
+﻿using System.Text.RegularExpressions;
+using FFXIVClientStructs.FFXIV.Client.Game.UI;
+using Lumina.Text.ReadOnly;
+
+namespace VanillaPlus.Features.QuestListWindow;
+
+public record QuestInfo(uint IconId, ReadOnlySeString Name, ushort Level, MapMarkerData MarkerData) {
+    public bool IsRegexMatch(string searchString) {
+        const RegexOptions regexOptions = RegexOptions.CultureInvariant | RegexOptions.IgnoreCase;
+    
+        if (Regex.IsMatch(Name.ToString(), searchString, regexOptions)) return true;
+        if (Regex.IsMatch(Level.ToString(), searchString, regexOptions)) return true;
+
+        return false;
+    }
+}

--- a/VanillaPlus/Features/QuestListWindow/QuestListWindow.cs
+++ b/VanillaPlus/Features/QuestListWindow/QuestListWindow.cs
@@ -1,0 +1,116 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using Dalamud.Game.ClientState.Keys;
+using FFXIVClientStructs.FFXIV.Client.Game.UI;
+using KamiToolKit.Nodes;
+using KamiToolKit.System;
+using VanillaPlus.Basic_Addons;
+using VanillaPlus.Classes;
+
+namespace VanillaPlus.Features.QuestListWindow;
+
+public unsafe class QuestListWindow : GameModification {
+    public override ModificationInfo ModificationInfo => new() {
+        DisplayName = "Quest List Window",
+        Description = "Displays a list of all available quests for the currently occupied zone.",
+        Type = ModificationType.NewWindow,
+        Authors = [ "MidoriKami" ],
+        ChangeLog = [
+            new ChangeLogInfo(1, "InitialChangelog"),
+        ],
+    };
+
+    private SearchableNodeListAddon? addonQuestList;
+    private string filterString = string.Empty;
+    private string searchString = string.Empty;
+    private bool filterReversed;
+    private bool updateRequested;
+
+    public override void OnEnable() {
+        addonQuestList = new SearchableNodeListAddon {
+            NativeController = System.NativeController,
+            Size = new Vector2(300.0f, 400.0f),
+            InternalName = "QuestList",
+            Title = "Quest List",
+            UpdateListFunction = UpdateList,
+            DropDownOptions = ["Alphabetically", "Level", "Type" ],
+            OnFilterUpdated = OnFilterUpdated,
+            OnSearchUpdated = OnSearchUpdated,
+            OpenCommand = "/questlist",
+        };
+        
+        addonQuestList.Initialize([VirtualKey.MENU, VirtualKey.CONTROL, VirtualKey.J]);
+
+        OpenConfigAction = addonQuestList.OpenAddonConfig;
+    }
+
+    public override void OnDisable() {
+        addonQuestList?.Dispose();
+        addonQuestList = null;
+    }
+
+    private void OnFilterUpdated(string newFilterString, bool reversed) {
+        updateRequested = true;
+        filterString = newFilterString;
+        filterReversed = reversed;
+        addonQuestList?.DoListUpdate();
+    }
+
+    private void OnSearchUpdated(string newSearchString) {
+        updateRequested = true;
+        searchString = newSearchString;
+        addonQuestList?.DoListUpdate();
+    }
+
+    private bool UpdateList(VerticalListNode listNode, bool isOpening) {
+        var filteredInventoryItems = GetQuests()
+            .Where(item => item.IsRegexMatch(searchString))
+            .ToList();
+
+        var listUpdated = listNode.SyncWithListData(filteredInventoryItems, node => node.QuestInfo, data => new QuestEntryNode {
+            Size = new Vector2(listNode.Width, 32.0f),
+            QuestInfo = data,
+            IsVisible = true,
+        });
+
+        if (listUpdated || updateRequested) {
+            listNode.ReorderNodes(Comparison);
+        }
+        
+        updateRequested = false;
+        return listUpdated;
+    }
+
+    private int Comparison(NodeBase x, NodeBase y) {
+        if (x is not QuestEntryNode left || y is not QuestEntryNode right) return 0;
+
+        var leftQuest = left.QuestInfo;
+        var rightQuest = right.QuestInfo;
+
+        var result = filterString switch {
+            "Alphabetically" => string.CompareOrdinal(leftQuest.Name.ToString(), rightQuest.Name.ToString()),
+            "Type" => rightQuest.MarkerData.IconId.CompareTo(leftQuest.MarkerData.IconId),
+            "Level" => rightQuest.Level.CompareTo(leftQuest.Level),
+            _ => string.CompareOrdinal(leftQuest.Name.ToString(), rightQuest.Name.ToString()),
+        };
+
+        var reverseModifier = filterReversed ? -1 : 1;
+        
+        return ( result is 0 ? string.CompareOrdinal(leftQuest.Name.ToString(), rightQuest.Name.ToString()) : result ) * reverseModifier;
+    }
+    
+    private static List<QuestInfo> GetQuests() {
+
+        List<QuestInfo> quests = [];
+        quests.AddRange(from questMarker in Map.Instance()->UnacceptedQuestMarkers 
+                        where questMarker is not { ObjectiveId: 0 } 
+                        select new QuestInfo(
+                            questMarker.MarkerData.First->IconId, 
+                            questMarker.Label.AsSpan(), 
+                            questMarker.RecommendedLevel,
+                            *questMarker.MarkerData.First));
+
+        return quests;
+    }
+}


### PR DESCRIPTION
Adds a new native window for displaying quest information.

Data is extracted from Map's Unaccepted Quest Markers, and then further processed with Lumina.

https://github.com/user-attachments/assets/2953a606-c04b-4cc6-bc9d-e70bd08e094f

<img width="305" height="187" alt="ffxiv_dx11_53vQm7a0GH" src="https://github.com/user-attachments/assets/84d1a959-4b61-4bf6-84b1-40d6c049109b" />

https://github.com/user-attachments/assets/659420fd-0079-4d0b-b4dc-c9624d797d34

