### PR TITLE
Add Hide MP Bars

### DIFF
--- a/VanillaPlus/Extensions/DataManagerExtensions.cs
+++ b/VanillaPlus/Extensions/DataManagerExtensions.cs
@@ -1,4 +1,6 @@
-﻿using Dalamud.Plugin.Services;
+﻿using System.Collections.Generic;
+using System.Linq;
+using Dalamud.Plugin.Services;
 using Lumina.Excel.Sheets;
 using Lumina.Text.ReadOnly;
 
@@ -7,4 +9,13 @@ namespace VanillaPlus.Extensions;
 public static class DataManagerExtensions {
     public static ReadOnlySeString GetAddonText(this IDataManager dataManager, uint id)
         => dataManager.GetExcelSheet<Addon>().GetRow(id).Text;
+
+    public static IEnumerable<uint> GetManaUsingClassJobs(this IDataManager dataManager) {
+        return dataManager.GetExcelSheet<Action>()
+            .Where(action => action.ClassJob.RowId is not (0 or uint.MaxValue))
+            .GroupBy(action => action.ClassJob.RowId)
+            .ToDictionary(group => group.Key, group => group.Any(action => action.PrimaryCostType is 3 or 96))
+            .Where(group => group.Value)
+            .Select(group => group.Key);
+    }
 }

--- a/VanillaPlus/Features/HideMpBars/HideMpBars.cs
+++ b/VanillaPlus/Features/HideMpBars/HideMpBars.cs
@@ -1,0 +1,57 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Dalamud.Game.Addon.Lifecycle;
+using Dalamud.Game.Addon.Lifecycle.AddonArgTypes;
+using FFXIVClientStructs.FFXIV.Client.Game.Group;
+using FFXIVClientStructs.FFXIV.Client.UI;
+using FFXIVClientStructs.FFXIV.Client.UI.Agent;
+using VanillaPlus.Classes;
+using VanillaPlus.Extensions;
+
+namespace VanillaPlus.Features.HideMpBars;
+
+// Template GameModification for more easily creating your own, can copy this entire folder and rename it.
+public unsafe class HideMpBars : GameModification {
+    public override ModificationInfo ModificationInfo => new() {
+        DisplayName = "Hide MP Bars",
+        Description = "Hides MP Bars in party list for jobs that don't use MP.",
+        Type = ModificationType.UserInterface,
+        Authors = [ "MidoriKami" ],
+        ChangeLog = [
+            new ChangeLogInfo(1, "InitialChangelog"),
+        ],
+    };
+
+    private List<uint>? manaUsingClassJobs;
+    
+    public override void OnEnable() {
+        manaUsingClassJobs = Services.DataManager.GetManaUsingClassJobs().ToList();
+        
+        Services.AddonLifecycle.RegisterListener(AddonEvent.PostDraw, "_PartyList", OnPartyListDraw);
+        Services.AddonLifecycle.RegisterListener(AddonEvent.PostRequestedUpdate, "_PartyList", OnPartyListDraw);
+    }
+
+    public override void OnDisable() {
+        Services.AddonLifecycle.UnregisterListener(OnPartyListDraw);
+        
+        manaUsingClassJobs = null;
+    }
+    
+    private void OnPartyListDraw(AddonEvent type, AddonArgs args) {
+        if (manaUsingClassJobs is null) return;
+        if (Services.ClientState.LocalPlayer is not { } localPlayer) return;
+
+        var addon = args.GetAddon<AddonPartyList>();
+
+        if (GroupManager.Instance()->MainGroup.MemberCount is 0) {
+            var mpGaugeNode = addon->PartyMembers[0].MPGaugeBar->OwnerNode;
+            mpGaugeNode->ToggleVisibility(manaUsingClassJobs.Contains(localPlayer.ClassJob.RowId));
+        }
+        else {
+            foreach (var hudMember in AgentHUD.Instance()->PartyMembers) {
+                var mpGaugeNode = addon->PartyMembers[hudMember.Index].MPGaugeBar->OwnerNode;
+                mpGaugeNode->ToggleVisibility(manaUsingClassJobs.Contains(hudMember.Object->ClassJob));
+            }
+        }
+    }
+}

--- a/VanillaPlus/Features/HideMpBars/HideMpBars.cs
+++ b/VanillaPlus/Features/HideMpBars/HideMpBars.cs
@@ -1,5 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using Dalamud.Game.Addon.Lifecycle;
 using Dalamud.Game.Addon.Lifecycle.AddonArgTypes;
 using FFXIVClientStructs.FFXIV.Client.Game.Group;
@@ -48,7 +50,11 @@ public unsafe class HideMpBars : GameModification {
             mpGaugeNode->ToggleVisibility(manaUsingClassJobs.Contains(localPlayer.ClassJob.RowId));
         }
         else {
-            foreach (var hudMember in AgentHUD.Instance()->PartyMembers) {
+            var hudMembers = Unsafe.AsPointer(ref AgentHUD.Instance()->PartyMembers[0]);
+            var hudMemberCount = AgentHUD.Instance()->PartyMemberCount;
+            var hudMemberSpan = new Span<HudPartyMember>(hudMembers, hudMemberCount);
+            
+            foreach (var hudMember in hudMemberSpan) {
                 var mpGaugeNode = addon->PartyMembers[hudMember.Index].MPGaugeBar->OwnerNode;
                 mpGaugeNode->ToggleVisibility(manaUsingClassJobs.Contains(hudMember.Object->ClassJob));
             }

--- a/VanillaPlus/Features/HideMpBars/HideMpBars.cs
+++ b/VanillaPlus/Features/HideMpBars/HideMpBars.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using Dalamud.Game.Addon.Lifecycle;
 using Dalamud.Game.Addon.Lifecycle.AddonArgTypes;
 using FFXIVClientStructs.FFXIV.Client.Game.Group;
@@ -50,11 +48,7 @@ public unsafe class HideMpBars : GameModification {
             mpGaugeNode->ToggleVisibility(manaUsingClassJobs.Contains(localPlayer.ClassJob.RowId));
         }
         else {
-            var hudMembers = Unsafe.AsPointer(ref AgentHUD.Instance()->PartyMembers[0]);
-            var hudMemberCount = AgentHUD.Instance()->PartyMemberCount;
-            var hudMemberSpan = new Span<HudPartyMember>(hudMembers, hudMemberCount);
-            
-            foreach (var hudMember in hudMemberSpan) {
+            foreach (var hudMember in AgentHUD.Instance()->GetSizedHudMemberSpan()) {
                 var mpGaugeNode = addon->PartyMembers[hudMember.Index].MPGaugeBar->OwnerNode;
                 mpGaugeNode->ToggleVisibility(manaUsingClassJobs.Contains(hudMember.Object->ClassJob));
             }


### PR DESCRIPTION
Hides MP bars in the partylist for jobs that don't use MP

<img width="296" height="207" alt="image" src="https://github.com/user-attachments/assets/871e180b-1993-49aa-bb91-cf81ba1d6daa" />

Hides the container for the bar itself, so any plugins modifying the underlaying text will not accidentally force the text visible again