### PR TITLE
Added option to change resource on Party Members and added Trust support

### DIFF
--- a/VanillaPlus/Features/ResourceBarPercentages/ResourceBarPercentages.cs
+++ b/VanillaPlus/Features/ResourceBarPercentages/ResourceBarPercentages.cs
@@ -1,10 +1,14 @@
+using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using Dalamud.Game.Addon.Lifecycle;
 using Dalamud.Game.Addon.Lifecycle.AddonArgTypes;
 using Dalamud.Game.ClientState.Objects.SubKinds;
+using Dalamud.Game.ClientState.Objects.Types;
 using FFXIVClientStructs.FFXIV.Client.UI;
 using FFXIVClientStructs.FFXIV.Client.UI.Agent;
 using FFXIVClientStructs.FFXIV.Client.UI.Arrays;
+using Lumina.Excel.Sheets;
 using VanillaPlus.Classes;
 using VanillaPlus.Extensions;
 
@@ -18,6 +22,7 @@ public unsafe class ResourceBarPercentages : GameModification {
         Authors = [ "Zeffuro" ],
         ChangeLog = [
             new ChangeLogInfo(1, "Initial Changelog"),
+            new ChangeLogInfo(2, "Added option to change resource on Party Members and added Trust support"),
         ],
         Tags = [ "Party List", "Parameter Bars" ],
     };
@@ -51,7 +56,7 @@ public unsafe class ResourceBarPercentages : GameModification {
 
     public override void OnDisable() {
         Services.AddonLifecycle.UnregisterListener(OnParameterDraw, OnPartyListDraw);
-       
+
         OnParameterDisable();
         OnPartyListDisable();
 
@@ -79,38 +84,90 @@ public unsafe class ResourceBarPercentages : GameModification {
         if (!config.PartyListEnabled) return;
 
         var addon = args.GetAddon<AddonPartyList>();
-        if (Services.ClientState.LocalPlayer is not { EntityId: var playerId } ) return;
+        if (Services.ClientState.LocalPlayer is not { ClassJob: { IsValid: true, Value: var classJob }, EntityId: var playerId } ) return;
+
+        var isTrustParty = addon->TrustCount > 0;
+
+        var trustMemberMap = new Dictionary<ulong, TrustMember>();
+        if (isTrustParty) {
+            trustMemberMap = CreateTrustMemberMap(addon);
+        }
 
         foreach (var hudMember in AgentHUD.Instance()->GetSizedHudMemberSpan()) {
             if (hudMember.EntityId == 0) continue;
-            ref var hudPartyMember = ref PartyListNumberArray.Instance()->PartyMembers[hudMember.Index];
-            ref var partyMember = ref addon->PartyMembers[hudMember.Index];
+            var isSelf = hudMember.EntityId == playerId;
+            var isTrustMember = !isSelf && isTrustParty;
 
-            var hpGaugeTextNode = partyMember.HPGaugeComponent->GetTextNodeById(2);
-            if (hpGaugeTextNode is not null) {
-                var isSelf = hudMember.EntityId == playerId;
-                if (isSelf && config.PartyListSelf || !isSelf && config.PartyListOtherMembers) {
-                    hpGaugeTextNode->SetText(GetCorrectText((uint)hudPartyMember.CurrentHealth, (uint)hudPartyMember.MaxHealth));
-                } else {
-                    hpGaugeTextNode->SetText(hudPartyMember.CurrentHealth.ToString());
-                }
+            if (isTrustMember && trustMemberMap.TryGetValue(hudMember.EntityId, out var trustMember)) {
+                ref var partyMember = ref addon->TrustMembers[trustMember.Index];
+                HandlePartyMember(ref partyMember, hudMember, isSelf, isTrustMember, classJob, trustMember.Chara);
+            } else {
+                ref var partyMember = ref addon->PartyMembers[hudMember.Index];
+                HandlePartyMember(ref partyMember, hudMember, isSelf, isTrustMember, classJob);
             }
         }
     }
 
-    private static void OnPartyListDisable() {
+    private void HandlePartyMember(ref AddonPartyList.PartyListMemberStruct partyMember, HudPartyMember hudMember, bool isSelf, bool isTrustMember, ClassJob classJob, IGameObject? gameObject = null, bool revertToDefault = false) {
+        if (config is null) return;
+        ref var hudPartyMember = ref PartyListNumberArray.Instance()->PartyMembers[hudMember.Index];
+        var currentHealth = hudPartyMember.CurrentHealth;
+        var maxHealth = hudPartyMember.MaxHealth;
+
+        if (isTrustMember && gameObject is not null) {
+            if (gameObject is not IBattleChara battleChara) return;
+            currentHealth = (int)battleChara.CurrentHp;
+            maxHealth = (int)battleChara.MaxHp;
+        }
+
+        var hpGaugeTextNode = partyMember.HPGaugeComponent->GetTextNodeById(2);
+        if (hpGaugeTextNode is not null) {
+            if ((isSelf && config.PartyListSelf || (!isSelf && config.PartyListOtherMembers)) && !revertToDefault) {
+                hpGaugeTextNode->SetText(GetCorrectText((uint)currentHealth, (uint)maxHealth, config.PartyListHpEnabled));
+            } else {
+                hpGaugeTextNode->SetText(currentHealth.ToString());
+            }
+        }
+
+        var resourceGaugeNode = partyMember.MPGaugeBar;
+        if (resourceGaugeNode is not null && !isTrustMember) {
+            var isCombatClass = !classJob.IsCrafter() && !classJob.IsGatherer();
+            if (!isSelf && !isCombatClass) return;
+
+            var shouldRevertResource = (isSelf && !config.PartyListSelf) || (!isSelf && !config.PartyListOtherMembers) || revertToDefault;
+            var isMpDisabled = (!config.PartyListMpEnabled || shouldRevertResource) && isCombatClass;
+            var resourceGaugeTextNode = resourceGaugeNode->GetTextNodeById(2);
+            var resourceGaugeTextSubNode = resourceGaugeNode->GetTextNodeById(3);
+
+            resourceGaugeTextNode->SetXShort((short)(isMpDisabled ? -17 : 4));
+            resourceGaugeTextNode->SetText(GetCorrectPartyResourceText((uint)hudPartyMember.CurrentMana, (uint)hudPartyMember.MaxMana, classJob, IsResourcePercentageEnabled(config, classJob), shouldRevertResource));
+            resourceGaugeTextSubNode->ToggleVisibility(isMpDisabled);
+        }
+    }
+
+    private void OnPartyListDisable() {
         var addon = Services.GameGui.GetAddonByName<AddonPartyList>("_PartyList");
         if (addon is null) return;
-        if (Services.ClientState.LocalPlayer is null) return;
+        if (Services.ClientState.LocalPlayer is not { ClassJob: { IsValid: true, Value: var classJob }, EntityId: var playerId } ) return;
+
+        var isTrustParty = addon->TrustCount > 0;
+
+        var trustMemberMap = new Dictionary<ulong, TrustMember>();
+        if (isTrustParty) {
+            trustMemberMap = CreateTrustMemberMap(addon);
+        }
 
         foreach (var hudMember in AgentHUD.Instance()->GetSizedHudMemberSpan()) {
             if (hudMember.EntityId == 0) continue;
-            ref var hudPartyMember = ref PartyListNumberArray.Instance()->PartyMembers[hudMember.Index];
-            ref var partyMember = ref addon->PartyMembers[hudMember.Index];
+            var isSelf = hudMember.EntityId == playerId;
+            var isTrustMember = !isSelf && isTrustParty;
 
-            var hpGaugeTextNode = partyMember.HPGaugeComponent->GetTextNodeById(2);
-            if (hpGaugeTextNode is not null) {
-                hpGaugeTextNode->SetText(hudPartyMember.CurrentHealth.ToString());
+            if (isTrustMember && trustMemberMap.TryGetValue(hudMember.EntityId, out var trustMember)) {
+                ref var partyMember = ref addon->TrustMembers[trustMember.Index];
+                HandlePartyMember(ref partyMember, hudMember, isSelf, isTrustMember, classJob, trustMember.Chara, true);
+            } else {
+                ref var partyMember = ref addon->PartyMembers[hudMember.Index];
+                HandlePartyMember(ref partyMember, hudMember, isSelf, isTrustMember, classJob, revertToDefault: true);
             }
         }
     }
@@ -128,6 +185,27 @@ public unsafe class ResourceBarPercentages : GameModification {
     private string GetCorrectText(uint current, uint max, bool enabled = true)
         => !enabled ? current.ToString() : FormatPercentage(current, max);
 
+    private string GetCorrectPartyResourceText(uint current, uint max, ClassJob classJob, bool enabled = true, bool revertToDefault = false) {
+        if (revertToDefault || (!classJob.IsCrafter() && !classJob.IsGatherer() && !enabled)) {
+            if (!classJob.IsCrafter() && !classJob.IsGatherer())
+                current /= 100; // Only divide MP for combat classes
+            return current.ToString();
+        }
+        return GetCorrectText(current, max, enabled);
+    }
+
+    private Dictionary<ulong, TrustMember> CreateTrustMemberMap(AddonPartyList* addon) {
+        var trustMemberMap = new Dictionary<ulong, TrustMember>();
+        for (var i = 0; i < addon->TrustCount; i++) {
+            var trustName = addon->TrustMembers[i].Name->GetText().ToString();
+            var trustChara = Services.ObjectTable.CharacterManagerObjects
+                .FirstOrDefault(member => member.Name.TextValue == SanitizeName(trustName));
+            if (trustChara != null)
+                trustMemberMap[trustChara.EntityId] = new TrustMember(i, trustChara);
+        }
+        return trustMemberMap;
+    }
+
     private string FormatPercentage(uint current, uint max) {
         if (config is null) return current.ToString();
         if (max == 0) return "0" + (config.PercentageSignEnabled ? "%" : "");
@@ -136,21 +214,35 @@ public unsafe class ResourceBarPercentages : GameModification {
         return percentage.ToString($"F{config.DecimalPlaces}", CultureInfo.InvariantCulture) + percentSign;
     }
 
+    private bool IsResourcePercentageEnabled(ResourceBarPercentagesConfig resourceConfig, ClassJob classJob) {
+        if (classJob.IsCrafter())
+            return resourceConfig.PartyListCpEnabled;
+        if (classJob.IsGatherer())
+            return resourceConfig.PartyListGpEnabled;
+        return resourceConfig.PartyListMpEnabled;
+    }
+
     private ActiveResource GetActiveResource(IPlayerCharacter player) {
         var defaultResource = new ActiveResource(0, 0, false);
         if (config is null) return defaultResource;
 
         if (player.MaxMp > 0)
             return new ActiveResource(player.CurrentMp, player.MaxMp, config.ParameterMpEnabled);
-        
+
         if (player.MaxGp > 0)
             return new ActiveResource (player.CurrentGp, player.MaxGp, config.ParameterGpEnabled);
-        
+
         if (player.MaxCp > 0)
             return new ActiveResource (player.CurrentCp, player.MaxCp, config.ParameterCpEnabled);
 
         return defaultResource;
     }
 
+    private string SanitizeName(string name) {
+        return new string(name.Where(c => !char.IsSurrogate(c) && (c < '\uE000' || c > '\uF8FF')).ToArray()).Trim();
+    }
+
     private record ActiveResource(uint Current, uint Max, bool Enabled);
+
+    private record TrustMember(int Index, IGameObject Chara);
 }

--- a/VanillaPlus/Features/ResourceBarPercentages/ResourceBarPercentagesConfig.cs
+++ b/VanillaPlus/Features/ResourceBarPercentages/ResourceBarPercentagesConfig.cs
@@ -8,6 +8,10 @@ public class ResourceBarPercentagesConfig : GameModificationConfig<ResourceBarPe
     public bool PartyListEnabled = true;
     public bool PartyListSelf = true;
     public bool PartyListOtherMembers = true;
+    public bool PartyListHpEnabled = true;
+    public bool PartyListMpEnabled = true;
+    public bool PartyListGpEnabled = true;
+    public bool PartyListCpEnabled = true;
 
     public bool ParameterWidgetEnabled = true;
     public bool ParameterHpEnabled = true;

--- a/VanillaPlus/Features/ResourceBarPercentages/ResourceBarPercentagesConfigWindow.cs
+++ b/VanillaPlus/Features/ResourceBarPercentages/ResourceBarPercentagesConfigWindow.cs
@@ -11,9 +11,24 @@ public class ResourceBarPercentagesConfigWindow(ResourceBarPercentagesConfig con
 
         if (config.PartyListEnabled) {
             using var indent = ImRaii.PushIndent();
-            
+
             if (ImGui.Checkbox("Player", ref config.PartyListSelf)) SaveConfigWithCallback();
             if (ImGui.Checkbox("Other Party Members", ref config.PartyListOtherMembers)) SaveConfigWithCallback();
+            ImGui.Spacing();
+            if (ImGui.Checkbox("HP##Party", ref config.PartyListHpEnabled)) SaveConfigWithCallback();
+            if (ImGui.Checkbox("MP##Party", ref config.PartyListMpEnabled)) SaveConfigWithCallback();
+            if (ImGui.Checkbox("GP##Party", ref config.PartyListGpEnabled)) SaveConfigWithCallback();
+            if (ImGui.IsItemHovered()) {
+                ImGui.BeginTooltip();
+                ImGui.Text("GP is only shown on the player.");
+                ImGui.EndTooltip();
+            }
+            if (ImGui.Checkbox("CP##Party", ref config.PartyListCpEnabled)) SaveConfigWithCallback();
+            if (ImGui.IsItemHovered()) {
+                ImGui.BeginTooltip();
+                ImGui.Text("CP is only shown on the player.");
+                ImGui.EndTooltip();
+            }
         }
 
         ImGui.Spacing();
@@ -23,18 +38,18 @@ public class ResourceBarPercentagesConfigWindow(ResourceBarPercentagesConfig con
         if (config.ParameterWidgetEnabled) {
             using var indent = ImRaii.PushIndent();
 
-            if (ImGui.Checkbox("HP", ref config.ParameterHpEnabled)) SaveConfigWithCallback();
-            if (ImGui.Checkbox("MP", ref config.ParameterMpEnabled)) SaveConfigWithCallback();
-            if (ImGui.Checkbox("GP", ref config.ParameterGpEnabled)) SaveConfigWithCallback();
-            if (ImGui.Checkbox("CP", ref config.ParameterCpEnabled)) SaveConfigWithCallback();
+            if (ImGui.Checkbox("HP##Parameter", ref config.ParameterHpEnabled)) SaveConfigWithCallback();
+            if (ImGui.Checkbox("MP##Parameter", ref config.ParameterMpEnabled)) SaveConfigWithCallback();
+            if (ImGui.Checkbox("GP##Parameter", ref config.ParameterGpEnabled)) SaveConfigWithCallback();
+            if (ImGui.Checkbox("CP##Parameter", ref config.ParameterCpEnabled)) SaveConfigWithCallback();
         }
 
         ImGui.Spacing();
 
         if (ImGui.Checkbox("Show Percentage Sign (%)", ref config.PercentageSignEnabled)) SaveConfigWithCallback();
-        
+
         ImGui.Spacing();
-        
+
         if (ImGui.SliderInt("Decimal Places", ref config.DecimalPlaces, 0, 2)) SaveConfigWithCallback();
     }
 


### PR DESCRIPTION
Adds the ability to change MP on party members and GP/CP on the players party list.

You're going to hate the code but let me clarify, I had to make a map because the indexes wouldn't always straight up match for the trust party struct. I could not find any number array for the trustmembers HP.

I tested this in Trusts (Both a dungeon and a 8man trial) and I tested Guildhests for party members as well as check if a party member being off the map doesn't blow up.

I'd say go ham on the code xD

https://github.com/user-attachments/assets/f610c390-0f39-42b0-a855-a8bc4ab28957

<img width="207" height="262" alt="ffxiv_dx11_2025-09-04_18-03-34" src="https://github.com/user-attachments/assets/685d54fd-c559-4d00-bd73-b4dcda9477d6" />
