### PR TITLE
Don't open Castbar Countdown config when Enabling

### DIFF
--- a/VanillaPlus/Features/TargetCastBarCountdown/TargetCastBarCountdown.cs
+++ b/VanillaPlus/Features/TargetCastBarCountdown/TargetCastBarCountdown.cs
@@ -73,8 +73,6 @@ public unsafe class TargetCastBarCountdown : GameModification {
         
         configWindow.AddCategory("Nameplate Castbar Style")
             .AddTextNodeConfig(CastBarEnemyStylePath, nodeConfigOptions);
-
-        configWindow.Open();
         
         config.OnSave += () => {
             // Node configurations may have changed, load them into the actual nodes.


### PR DESCRIPTION
Will stop this window from appearing when the plugin is loaded, as it triggers at the title screen