### PR TITLE
Add compatibility check for search bars

### DIFF
--- a/VanillaPlus/Features/ArmourySearchBar/ArmourySearchBar.cs
+++ b/VanillaPlus/Features/ArmourySearchBar/ArmourySearchBar.cs
@@ -13,7 +13,9 @@ public class ArmourySearchBar : GameModification {
         Authors = [ "MidoriKami" ],
         ChangeLog = [
             new ChangeLogInfo(1, "InitialChangelog"),
+            new ChangeLogInfo(2, "Add compatibility check"),
         ],
+        CompatibilityModule = new PluginCompatibilityModule("InventorySearchBar"),
     };
 
     private InventorySearchAddonController? armouryInventoryController;

--- a/VanillaPlus/Features/InventorySearchBar/InventorySearchBar.cs
+++ b/VanillaPlus/Features/InventorySearchBar/InventorySearchBar.cs
@@ -11,7 +11,9 @@ public class InventorySearchBar : GameModification {
         Authors = [ "MidoriKami" ],
         ChangeLog = [
             new ChangeLogInfo(1, "InitialChangelog"),
+            new ChangeLogInfo(2, "Add compatibility check"),
         ],
+        CompatibilityModule = new PluginCompatibilityModule("InventorySearchBar"),
     };
 
     public override string ImageName => "InventorySearchBar.png";

--- a/VanillaPlus/Features/RetainerSearchBar/RetainerSearchBar.cs
+++ b/VanillaPlus/Features/RetainerSearchBar/RetainerSearchBar.cs
@@ -11,7 +11,9 @@ public class RetainerSearchBar : GameModification {
         Authors = [ "MidoriKami" ],
         ChangeLog = [
             new ChangeLogInfo(1, "InitialChangelog"),
+            new ChangeLogInfo(2, "Add compatibility check"),
         ],
+        CompatibilityModule = new PluginCompatibilityModule("InventorySearchBar"),
     };
 
     private InventorySearchAddonController? retainerInventoryController;

--- a/VanillaPlus/Features/SaddlebagSearchBar/SaddlebagSearchBar.cs
+++ b/VanillaPlus/Features/SaddlebagSearchBar/SaddlebagSearchBar.cs
@@ -11,7 +11,9 @@ public class SaddlebagSearchBar : GameModification {
         Authors = [ "MidoriKami" ],
         ChangeLog = [
             new ChangeLogInfo(1, "InitialChangelog"),
+            new ChangeLogInfo(2, "Add compatibility check"),
         ],
+        CompatibilityModule = new PluginCompatibilityModule("InventorySearchBar"),
     };
 
     private InventorySearchAddonController? saddlebagInventoryController;


### PR DESCRIPTION
Inventory Search Bar may overwrite the fade state, causing the search bar to malfunction.

<img width="479" height="162" alt="snipaste_20251106_082401" src="https://github.com/user-attachments/assets/b74150ba-c2ef-425c-a398-344efa8b8930" />
