### PR TITLE
Adds item types and gear job as possible search terms

### DIFF
--- a/VanillaPlus/Extensions/InventoryItemExtensions.cs
+++ b/VanillaPlus/Extensions/InventoryItemExtensions.cs
@@ -89,6 +89,8 @@ public static class InventoryItemExtensions {
                     if (regex.IsMatch(itemData.Description.ToString()) && isDescriptionSearch) return true;
                     if (regex.IsMatch(itemData.LevelEquip.ToString())) return true;
                     if (regex.IsMatch(itemData.LevelItem.RowId.ToString())) return true;
+                    if (regex.IsMatch(itemData.ClassJobCategory.Value.Name.ToString())) return true;
+                    if (regex.IsMatch(itemData.ItemUICategory.Value.Name.ToString())) return true;
                 }
             }
             catch (RegexParseException) { }


### PR DESCRIPTION
Allows you to do stuff like:
- "meal" to light up all your food items
- "medicine" to light up your potions
- "blm" to light up all the gear pieces for black mage
- etc

I would also suggest to provide some examples / help so the users know what they can search for and how to do it.
Maybe in the tooltip? I wasn't sure you'd want that so I didn't go for it.
