### PR TITLE
I18n

### DIFF
--- a/VanillaPlus/Features/ArmourySearchBar/ArmourySearchBar.cs
+++ b/VanillaPlus/Features/ArmourySearchBar/ArmourySearchBar.cs
@@ -6,8 +6,8 @@ namespace VanillaPlus.Features.ArmourySearchBar;
 
 public class ArmourySearchBar : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Armoury Search Bar",
-        Description = "Adds a search bar to the armoury window.",
+        DisplayName = Strings("ModificationDisplay_ArmourySearchBar"),
+        Description = Strings("ModificationDescription_ArmourySearchBar"),
         Type = ModificationType.UserInterface,
         SubType = ModificationSubType.Inventory,
         Authors = [ "MidoriKami" ],

--- a/VanillaPlus/Features/BetterCursor/BetterCursor.cs
+++ b/VanillaPlus/Features/BetterCursor/BetterCursor.cs
@@ -8,8 +8,8 @@ namespace VanillaPlus.Features.BetterCursor;
 
 public class BetterCursor : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Better Cursor",
-        Description = "Draws a ring around the cursor to make it easier to see.",
+        DisplayName = Strings("ModificationDisplay_BetterCursor"),
+        Description = Strings("ModificationDescription_BetterCursor"),
         Authors = ["MidoriKami"],
         Type = ModificationType.UserInterface,
         ChangeLog = [
@@ -31,24 +31,24 @@ public class BetterCursor : GameModification {
 
         configWindow = new ConfigAddon {
             InternalName = "BetterCursorConfig",
-            Title = "Better Cursor Config",
+            Title = Strings("BetterCursor_ConfigTitle"),
             Config = config,
         };
 
-        configWindow.AddCategory("Style")
-            .AddColorEdit("Color", nameof(config.Color), KnownColor.White.Vector())
-            .AddInputFloat("Size", 16, 16..512, nameof(config.Size));
+        configWindow.AddCategory(Strings("BetterCursor_CategoryStyle"))
+            .AddColorEdit(Strings("BetterCursor_LabelColor"), nameof(config.Color), KnownColor.White.Vector())
+            .AddInputFloat(Strings("BetterCursor_LabelSize"), 16, 16..512, nameof(config.Size));
 
-        configWindow.AddCategory("Functions")
-            .AddCheckbox("Enable Animation", nameof(config.Animations))
-            .AddCheckbox("Hide on Left-Hold or Right-Hold", nameof(config.HideOnCameraMove));
+        configWindow.AddCategory(Strings("BetterCursor_CategoryFunctions"))
+            .AddCheckbox(Strings("BetterCursor_EnableAnimation"), nameof(config.Animations))
+            .AddCheckbox(Strings("BetterCursor_HideOnCameraMove"), nameof(config.HideOnCameraMove));
         
-        configWindow.AddCategory("Visibility")
-            .AddCheckbox("Only show in Combat", nameof(config.OnlyShowInCombat))
-            .AddCheckbox("Only Show in Duties", nameof(config.OnlyShowInDuties));
+        configWindow.AddCategory(Strings("BetterCursor_CategoryVisibility"))
+            .AddCheckbox(Strings("BetterCursor_OnlyShowInCombat"), nameof(config.OnlyShowInCombat))
+            .AddCheckbox(Strings("BetterCursor_OnlyShowInDuties"), nameof(config.OnlyShowInDuties));
 
-        configWindow.AddCategory("Icon Selection")
-            .AddSelectIcon("Icon", nameof(config.IconId));
+        configWindow.AddCategory(Strings("BetterCursor_CategoryIconSelection"))
+            .AddSelectIcon(Strings("BetterCursor_LabelIcon"), nameof(config.IconId));
 
         OpenConfigAction = configWindow.Toggle;
 

--- a/VanillaPlus/Features/BetterInterruptableCastBars/BetterInterruptableCastBars.cs
+++ b/VanillaPlus/Features/BetterInterruptableCastBars/BetterInterruptableCastBars.cs
@@ -15,8 +15,8 @@ namespace VanillaPlus.Features.BetterInterruptableCastBars;
 
 public unsafe class BetterInterruptableCastBars : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Better Interruptable Castbars",
-        Description = "Makes enemy interruptable castbars much more noticeable.\n\nAdditionally skills that can interrupt the cast are indicated on your hotbar.",
+        DisplayName = Strings("ModificationDisplay_BetterInterruptableCastBars"),
+        Description = Strings("ModificationDescription_BetterInterruptableCastBars"),
         Type = ModificationType.UserInterface,
         Authors = [ "MidoriKami" ],
         ChangeLog = [

--- a/VanillaPlus/Features/BetterQuestMapLink/BetterQuestMapLink.cs
+++ b/VanillaPlus/Features/BetterQuestMapLink/BetterQuestMapLink.cs
@@ -7,8 +7,8 @@ namespace VanillaPlus.Features.BetterQuestMapLink;
 
 public unsafe class BetterQuestMapLink : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Better Quest Map Link",
-        Description = "When clicking on quest links, open the actual map the quest is for instead of the generic world map.",
+        DisplayName = Strings("ModificationDisplay_BetterQuestMapLink"),
+        Description = Strings("ModificationDescription_BetterQuestMapLink"),
         Type = ModificationType.GameBehavior,
         Authors = [ "MidoriKami" ],
         ChangeLog = [

--- a/VanillaPlus/Features/CastBarAetheryteNames/CastBarAetheryteNames.cs
+++ b/VanillaPlus/Features/CastBarAetheryteNames/CastBarAetheryteNames.cs
@@ -11,8 +11,8 @@ namespace VanillaPlus.Features.CastBarAetheryteNames;
 
 public unsafe class CastBarAetheryteNames : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Cast Bar Aetheryte Names",
-        Description = "Replaces the name of the action 'Teleport' with the Aetheryte name of your destination.",
+        DisplayName = Strings("ModificationDisplay_CastBarAetheryteNames"),
+        Description = Strings("ModificationDescription_CastBarAetheryteNames"),
         Authors = ["Haselnussbomber"],
         Type = ModificationType.GameBehavior,
         ChangeLog = [

--- a/VanillaPlus/Features/ClearFlag/ClearFlag.cs
+++ b/VanillaPlus/Features/ClearFlag/ClearFlag.cs
@@ -10,8 +10,8 @@ namespace VanillaPlus.Features.ClearFlag;
 
 public unsafe class ClearFlag : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Clear Flag",
-        Description = "Allows you to right click the minimap to clear the currently set flag marker.",
+        DisplayName = Strings("ModificationDisplay_ClearFlag"),
+        Description = Strings("ModificationDescription_ClearFlag"),
         Type = ModificationType.GameBehavior,
         Authors = [ "MidoriKami" ],
         ChangeLog = [

--- a/VanillaPlus/Features/ClearSelectedDuties/ClearSelectedDuties.cs
+++ b/VanillaPlus/Features/ClearSelectedDuties/ClearSelectedDuties.cs
@@ -11,8 +11,8 @@ namespace VanillaPlus.Features.ClearSelectedDuties;
 
 public class ClearSelectedDuties : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Clear Selected Duties",
-        Description = "When opening the Duty Finder, deselects any selected duties.",
+        DisplayName = Strings("ModificationDisplay_ClearSelectedDuties"),
+        Description = Strings("ModificationDescription_ClearSelectedDuties"),
         Authors = [ "MidoriKami" ],
         Type = ModificationType.GameBehavior,
         ChangeLog = [
@@ -28,12 +28,12 @@ public class ClearSelectedDuties : GameModification {
         configWindow = new ConfigAddon {
             Size = new Vector2(300.0f, 135.0f),
             InternalName = "ClearSelectedConfig",
-            Title = "Clear Selected Duties Config",
+            Title = Strings("ClearSelectedDuties_ConfigTitle"),
             Config = config,
         };
 
-        configWindow.AddCategory("Settings")
-            .AddCheckbox("Disable when Unrestricted", nameof(config.DisableWhenUnrestricted));
+        configWindow.AddCategory(Strings("ClearSelectedDuties_SettingsCategory"))
+            .AddCheckbox(Strings("ClearSelectedDuties_DisableWhenUnrestricted"), nameof(config.DisableWhenUnrestricted));
         
         OpenConfigAction = configWindow.Toggle;
         

--- a/VanillaPlus/Features/ClearTextInputs/ClearTextInputs.cs
+++ b/VanillaPlus/Features/ClearTextInputs/ClearTextInputs.cs
@@ -10,8 +10,8 @@ namespace VanillaPlus.Features.ClearTextInputs;
 
 public unsafe class ClearTextInputs : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Clear Text Inputs",
-        Description = "Allows you to clear the text in a text input, by right clicking the text input.",
+        DisplayName = Strings("ModificationDisplay_ClearTextInputs"),
+        Description = Strings("ModificationDescription_ClearTextInputs"),
         Type = ModificationType.GameBehavior,
         Authors = [ "MidoriKami" ],
         ChangeLog = [

--- a/VanillaPlus/Features/CurrencyOverlay/CurrencyOverlay.cs
+++ b/VanillaPlus/Features/CurrencyOverlay/CurrencyOverlay.cs
@@ -11,9 +11,8 @@ namespace VanillaPlus.Features.CurrencyOverlay;
 
 public unsafe class CurrencyOverlay : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Currency Overlay",
-        Description = "Allows you to add additional currencies to your UI Overlay.\n\n" +
-                      "Additionally allows you to set minimum and maximum values to trigger a warning.",
+        DisplayName = Strings("ModificationDisplay_CurrencyOverlay"),
+        Description = Strings("ModificationDescription_CurrencyOverlay"),
         Type = ModificationType.NewOverlay,
         Authors = [ "MidoriKami" ],
         ChangeLog = [
@@ -40,22 +39,22 @@ public unsafe class CurrencyOverlay : GameModification {
         
         itemSearchAddon = new LuminaSearchAddon<Item> {
             InternalName = "LuminaItemSearch",
-            Title = "Item Search",
+            Title = Strings("CurrencyOverlay_ItemSearchTitle"),
             Size = new Vector2(350.0f, 500.0f),
 
             GetLabelFunc = item => item.Name.ToString(),
             GetSubLabelFunc = item => item.ItemSearchCategory.Value.Name.ToString(),
             GetIconIdFunc = item => item.Icon,
 
-            SortingOptions = [ "Alphabetical", "Id" ],
+            SortingOptions = [ Strings("CurrencyOverlay_SortOptionAlphabetical"), Strings("CurrencyOverlay_SortOptionId") ],
             SearchOptions = Services.DataManager.GetCurrencyItems().ToList(),
         };
 
         configAddon = new ListConfigAddon<CurrencySetting, CurrencyOverlayConfigNode> {
             Size = new Vector2(700.0f, 500.0f),
             InternalName = "CurrencyOverlayConfig",
-            Title = "Currency Overlay Config",
-            SortOptions = [ "Alphabetical" ],
+            Title = Strings("CurrencyOverlay_ConfigTitle"),
+            SortOptions = [ Strings("CurrencyOverlay_SortOptionAlphabetical") ],
 
             Options = config.Currencies,
 

--- a/VanillaPlus/Features/CurrencyOverlay/CurrencySetting.cs
+++ b/VanillaPlus/Features/CurrencyOverlay/CurrencySetting.cs
@@ -36,7 +36,7 @@ public class CurrencySetting : IInfoNodeData {
 
     public int Compare(IInfoNodeData other, string sortingMode) {
         return sortingMode switch {
-            "Alphabetical" => string.CompareOrdinal(GetLabel(), other.GetLabel()),
+            var s when s == Strings("SortOption_Alphabetical") => string.CompareOrdinal(GetLabel(), other.GetLabel()),
             _ => 0,
         };
     }

--- a/VanillaPlus/Features/DebugCustomAddon/DebugCustomAddon.cs
+++ b/VanillaPlus/Features/DebugCustomAddon/DebugCustomAddon.cs
@@ -10,8 +10,8 @@ namespace VanillaPlus.Features.DebugCustomAddon;
 /// </summary>
 public class DebugCustomAddon : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Debug CustomAddon",
-        Description = "A module for playing around and testing VanillaPlus features",
+        DisplayName = Strings("ModificationDisplay_DebugCustomAddon"),
+        Description = Strings("ModificationDescription_DebugCustomAddon"),
         Type = ModificationType.Debug,
         Authors = [ "YourNameHere" ],
         ChangeLog = [
@@ -24,7 +24,7 @@ public class DebugCustomAddon : GameModification {
     public override void OnEnable() {
         debugAddon = new DebugAddon {
             InternalName = "DebugAddon",
-            Title = "Debug Addon Window",
+            Title = Strings("DebugCustomAddon_Title"),
             Size = new Vector2(500.0f, 500.0f),
         };
 

--- a/VanillaPlus/Features/DebugGameModification/DebugGameModification.cs
+++ b/VanillaPlus/Features/DebugGameModification/DebugGameModification.cs
@@ -8,8 +8,8 @@ namespace VanillaPlus.Features.DebugGameModification;
 /// </summary>
 public class DebugGameModification : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Debug GameModification",
-        Description = "A module for playing around and testing VanillaPlus features",
+        DisplayName = Strings("ModificationDisplay_DebugGameModification"),
+        Description = Strings("ModificationDescription_DebugGameModification"),
         Type = ModificationType.Debug,
         Authors = [ "YourNameHere" ],
         ChangeLog = [

--- a/VanillaPlus/Features/DraggableWindowDeadSpace/DraggableWindowDeadSpace.cs
+++ b/VanillaPlus/Features/DraggableWindowDeadSpace/DraggableWindowDeadSpace.cs
@@ -13,8 +13,8 @@ namespace VanillaPlus.Features.DraggableWindowDeadSpace;
 
 public unsafe class DraggableWindowDeadSpace : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Draggable Window Dead Space",
-        Description = "Allows clicking and dragging on window dead space to move the window.",
+        DisplayName = Strings("ModificationDisplay_DraggableWindowDeadSpace"),
+        Description = Strings("ModificationDescription_DraggableWindowDeadSpace"),
         Type = ModificationType.GameBehavior,
         Authors = [ "MidoriKami" ],
         ChangeLog = [

--- a/VanillaPlus/Features/DutyLootPreview/DutyLootAddon.cs
+++ b/VanillaPlus/Features/DutyLootPreview/DutyLootAddon.cs
@@ -22,10 +22,9 @@ namespace VanillaPlus.Features.DutyLootPreview;
 /// The window that shows loot for a duty.
 /// </summary>
 public unsafe class DutyLootPreviewAddon : NativeAddon {
-    private const string NoItemsMessage = "No loot data found for this duty.\n\n" +
-                                          "Data is provided by a third party and may be incomplete.";
-    private const string NoResultsMessage = "No results";
-    private const string LoadingMessage = "Loading loot data...";
+    private static string NoItemsMessage => Strings("DutyLoot_NoItemsMessage");
+    private static string NoResultsMessage => Strings("DutyLoot_NoResultsMessage");
+    private static string LoadingMessage => Strings("DutyLoot_LoadingMessage");
 
     private DutyLootFilterBarNode? filterBarNode;
     private HorizontalLineNode? separatorNode;
@@ -125,12 +124,14 @@ public unsafe class DutyLootPreviewAddon : NativeAddon {
         contextMenu.Clear();
 
         if (item.CanTryOn) {
-            contextMenu.AddItem("Try On", () => AgentTryon.TryOn(0, item.ItemId));
+            contextMenu.AddItem(Strings("DutyLoot_Context_TryOn"), () => AgentTryon.TryOn(0, item.ItemId));
         }
 
         var isFavorite = Config.FavoriteItems.Contains(item.ItemId);
         contextMenu.AddItem(new ContextMenuItem {
-            Name = isFavorite ? "Remove from Favorites" : "Add to Favorites",
+            Name = isFavorite
+                ? Strings("DutyLoot_Context_RemoveFavorite")
+                : Strings("DutyLoot_Context_AddFavorite"),
             OnClick = () => {
                 if (isFavorite) {
                     Config.FavoriteItems.Remove(item.ItemId);
@@ -142,9 +143,9 @@ public unsafe class DutyLootPreviewAddon : NativeAddon {
             },
         });
 
-        contextMenu.AddItem("Search for Item", () => ItemFinderModule.Instance()->SearchForItem(item.ItemId));
-        contextMenu.AddItem("Link", () => AgentChatLog.Instance()->LinkItem(item.ItemId));
-        contextMenu.AddItem("Search Recipes Using This Material", () => AgentRecipeProductList.Instance()->SearchForRecipesUsingItem(item.ItemId));
+        contextMenu.AddItem(Strings("DutyLoot_Context_SearchItem"), () => ItemFinderModule.Instance()->SearchForItem(item.ItemId));
+        contextMenu.AddItem(Strings("DutyLoot_Context_Link"), () => AgentChatLog.Instance()->LinkItem(item.ItemId));
+        contextMenu.AddItem(Strings("DutyLoot_Context_SearchRecipes"), () => AgentRecipeProductList.Instance()->SearchForRecipesUsingItem(item.ItemId));
 
         contextMenu.Open();
     }

--- a/VanillaPlus/Features/DutyLootPreview/DutyLootFilterBarNode.cs
+++ b/VanillaPlus/Features/DutyLootPreview/DutyLootFilterBarNode.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Numerics;
 using FFXIVClientStructs.FFXIV.Component.GUI;
 using KamiToolKit.Nodes;
+using Lumina.Text;
 using Lumina.Text.ReadOnly;
 
 namespace VanillaPlus.Features.DutyLootPreview;
@@ -30,19 +31,19 @@ public class DutyLootFilterBarNode : HorizontalListNode {
     public DutyLootFilterBarNode() {
         ItemSpacing = 1;
 
-        AddButton(LootFilter.All, 61808, "All Items");
-        AddButton(LootFilter.Favorites, 61830, "Favorites");
-        AddButton(LootFilter.Equipment, 61828, "Equipment");
-        AddButton(LootFilter.Misc, 61807, "Miscellaneous");
+        AddButton(LootFilter.All, 61808, Strings("DutyLoot_Filter_All"));
+        AddButton(LootFilter.Favorites, 61830, Strings("DutyLoot_Filter_Favorites"));
+        AddButton(LootFilter.Equipment, 61828, Strings("DutyLoot_Filter_Equipment"));
+        AddButton(LootFilter.Misc, 61807, Strings("DutyLoot_Filter_Misc"));
 
         UpdateButtonStates();
     }
 
-    private void AddButton(LootFilter filter, uint iconId, ReadOnlySeString tooltip) {
+    private void AddButton(LootFilter filter, uint iconId, string tooltipText) {
         var button = new IconToggleNode {
             Size = new Vector2(36, 36),
             IconId = iconId,
-            Tooltip = tooltip,
+            Tooltip = new SeStringBuilder().Append(tooltipText).ToReadOnlySeString(),
         };
 
         button.CollisionNode.AddEvent(AtkEventType.MouseClick, () => {

--- a/VanillaPlus/Features/DutyLootPreview/DutyLootInDutyButtonNode.cs
+++ b/VanillaPlus/Features/DutyLootPreview/DutyLootInDutyButtonNode.cs
@@ -27,7 +27,7 @@ public unsafe class DutyLootInDutyButtonNode : OverlayNode {
             TextureCoordinates = new Vector2(90.0f, 125.0f),
             TextureSize = new Vector2(32.0f, 32.0f),
             Size = new Vector2(20.0f, 20.0f),
-            TooltipString = "[VanillaPlus] Open Duty Loot Preview Window",
+            TooltipString = Strings("DutyLoot_Tooltip_InDutyButton"),
         };
         buttonNode.AttachNode(this);
 

--- a/VanillaPlus/Features/DutyLootPreview/DutyLootJournalUiController.cs
+++ b/VanillaPlus/Features/DutyLootPreview/DutyLootJournalUiController.cs
@@ -43,7 +43,7 @@ public unsafe class DutyLootJournalUiController {
 
             Position = new Vector2(420.0f, 68.0f),
             Size = new Vector2(32.0f, 32.0f),
-            TooltipString = "View Loot that can be earned in this duty.",
+            TooltipString = Strings("DutyLoot_Tooltip_JournalButton"),
             OnClick = () => OnButtonClicked?.Invoke(),
         };
         lootButtonNode.AttachNode(dutyTitleNode, NodePosition.AfterTarget);

--- a/VanillaPlus/Features/DutyLootPreview/DutyLootPreview.cs
+++ b/VanillaPlus/Features/DutyLootPreview/DutyLootPreview.cs
@@ -5,8 +5,8 @@ namespace VanillaPlus.Features.DutyLootPreview;
 
 public class DutyLootPreview : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Duty Loot Preview",
-        Description = "Adds a duty loot viewer to the duty window.",
+        DisplayName = Strings("ModificationDisplay_DutyLootPreview"),
+        Description = Strings("ModificationDescription_DutyLootPreview"),
         Type = ModificationType.NewWindow,
         Authors = [ "GrittyFrog" ],
         ChangeLog = [
@@ -28,7 +28,7 @@ public class DutyLootPreview : GameModification {
         
         addonDutyLoot = new DutyLootPreviewAddon {
             InternalName = "DutyLootPreview",
-            Title = "Duty Loot Preview",
+            Title = Strings("Title_DutyLootPreview"),
             Size = new Vector2(300.0f, 350.0f),
             Config = config,
         };

--- a/VanillaPlus/Features/DutyTimer/DutyTimer.cs
+++ b/VanillaPlus/Features/DutyTimer/DutyTimer.cs
@@ -5,8 +5,8 @@ namespace VanillaPlus.Features.DutyTimer;
 
 public class DutyTimer : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Duty Timer",
-        Description = "When completing a duty, prints the time the duty took to chat.",
+        DisplayName = Strings("ModificationDisplay_DutyTimer"),
+        Description = Strings("ModificationDescription_DutyTimer"),
         Authors = [ "MidoriKami" ],
         Type = ModificationType.GameBehavior,
         ChangeLog = [
@@ -32,8 +32,11 @@ public class DutyTimer : GameModification {
     private void OnDutyStarted(object? sender, ushort e)
         => startTimestamp = DateTime.UtcNow;
 
-    private void OnDutyCompleted(object? sender, ushort e)
-        => Services.ChatGui.Print($@"Duty Completed in: {DateTime.UtcNow - startTimestamp:hh\:mm\:ss\.ffff}");
+    private void OnDutyCompleted(object? sender, ushort e) {
+        var duration = DateTime.UtcNow - startTimestamp;
+        var formattedDuration = duration.ToString(@"hh\:mm\:ss\.ffff");
+        Services.ChatGui.Print(Strings("DutyTimer_CompletedMessage", formattedDuration));
+    }
 
     private void OnTerritoryChanged(ushort obj)
         => startTimestamp = DateTime.UtcNow;

--- a/VanillaPlus/Features/EnhancedLootWindow/EnhancedLootWindow.cs
+++ b/VanillaPlus/Features/EnhancedLootWindow/EnhancedLootWindow.cs
@@ -17,8 +17,8 @@ namespace VanillaPlus.Features.EnhancedLootWindow;
 
 public unsafe class EnhancedLootWindow : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Enhanced Loot Window",
-        Description = "Adds indicators to loot window items to indicate if you have unlocked that item before, or if the item is obtainable.",
+        DisplayName = Strings("ModificationDisplay_EnhancedLootWindow"),
+        Description = Strings("ModificationDescription_EnhancedLootWindow"),
         Type = ModificationType.UserInterface,
         Authors = ["MidoriKami"],
         ChangeLog = [
@@ -38,15 +38,16 @@ public unsafe class EnhancedLootWindow : GameModification {
 
     public override void OnEnable() {
         config = EnhancedLootWindowConfig.Load();
+
         configWindow = new ConfigAddon {
             InternalName = "EnhancedLootWindowConfig",
-            Title = "Enhanced Loot Window Config",
+            Title = Strings("EnhancedLootWindow_ConfigTitle"),
             Config = config,
         };
 
-        configWindow.AddCategory("Settings")
-            .AddCheckbox("Mark Unobtainable Items", nameof(config.MarkUnobtainableItems))
-            .AddCheckbox("Mark Already Unlocked Items", nameof(config.MarkAlreadyObtainedItems));
+        configWindow.AddCategory(Strings("EnhancedLootWindow_CategorySettings"))
+            .AddCheckbox(Strings("EnhancedLootWindow_LabelMarkUnobtainable"), nameof(config.MarkUnobtainableItems))
+            .AddCheckbox(Strings("EnhancedLootWindow_LabelMarkAlreadyObtained"), nameof(config.MarkAlreadyObtainedItems));
 
         OpenConfigAction = configWindow.Toggle;
 

--- a/VanillaPlus/Features/FadeLootButton/FadeLootButton.cs
+++ b/VanillaPlus/Features/FadeLootButton/FadeLootButton.cs
@@ -9,8 +9,8 @@ namespace VanillaPlus.Features.FadeLootButton;
 
 public unsafe class FadeLootButton : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Fade Loot Button",
-        Description = "Fades the Loot button if you've already rolled on everything available.",
+        DisplayName = Strings("ModificationDisplay_FadeLootButton"),
+        Description = Strings("ModificationDescription_FadeLootButton"),
         Type = ModificationType.UserInterface,
         Authors = [ "MidoriKami" ],
         ChangeLog = [
@@ -26,16 +26,16 @@ public unsafe class FadeLootButton : GameModification {
     
     public override void OnEnable() {
         config = FadeLootButtonConfig.Load();
-        
+
         configWindow = new ConfigAddon {
             Size = new Vector2(400.0f, 125.0f),
             InternalName = "FadeLootConfig",
-            Title = "Fade Loot Button Config",
+            Title = Strings("FadeLootButton_ConfigTitle"),
             Config = config,
         };
 
-        configWindow.AddCategory("Style Settings")
-            .AddFloatSlider("Fade Percentage", 0.0f, 1.0f, 2, 0.05f, nameof(config.FadePercent));
+        configWindow.AddCategory(Strings("FadeLootButton_CategoryStyleSettings"))
+            .AddFloatSlider(Strings("FadeLootButton_LabelFadePercentage"), 0.0f, 1.0f, 2, 0.05f, nameof(config.FadePercent));
 
         OpenConfigAction = configWindow.Toggle;
         

--- a/VanillaPlus/Features/FadeUnavailableActions/FadeUnavailableActions.cs
+++ b/VanillaPlus/Features/FadeUnavailableActions/FadeUnavailableActions.cs
@@ -14,9 +14,8 @@ namespace VanillaPlus.Features.FadeUnavailableActions;
 
 public unsafe class FadeUnavailableActions : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Fade Unavailable Actions",
-        Description = "Fades hotbar slots when the action is not able to be cast due to missing resources, out of range, or just on cooldown.\n\n" +
-                      "Additionally fades actions that are not available because you are sync'd down.",
+        DisplayName = Strings("ModificationDisplay_FadeUnavailableActions"),
+        Description = Strings("ModificationDescription_FadeUnavailableActions"),
         Authors = ["MidoriKami"],
         Type = ModificationType.UserInterface,
         ChangeLog = [
@@ -38,21 +37,22 @@ public unsafe class FadeUnavailableActions : GameModification {
         actionCache = [];
 
         config = FadeUnavailableActionsConfig.Load();
+
         configWindow = new ConfigAddon {
             Size = new Vector2(400.0f, 250.0f),
             InternalName = "FadeUnavailableConfig",
-            Title = "Fade Unavailable Actions Config",
+            Title = Strings("FadeUnavailableActions_ConfigTitle"),
             Config = config,
         };
 
-        configWindow.AddCategory("Style Settings")
-            .AddIntSlider("Fade Percentage", 0, 90, nameof(config.FadePercentage))
-            .AddIntSlider("Redden Percentage", 5, 100,  nameof(config.ReddenPercentage));
+        configWindow.AddCategory(Strings("FadeUnavailableActions_CategoryStyleSettings"))
+            .AddIntSlider(Strings("FadeUnavailableActions_LabelFadePercentage"), 0, 90, nameof(config.FadePercentage))
+            .AddIntSlider(Strings("FadeUnavailableActions_LabelReddenPercentage"), 5, 100, nameof(config.ReddenPercentage));
 
-        configWindow.AddCategory("Feature Toggles")
-            .AddCheckbox("Apply Transparency to Frame", nameof(config.ApplyToFrame))
-            .AddCheckbox("Apply Only to Sync'd Actions", nameof(config.ApplyToSyncActions))
-            .AddCheckbox("Redden Skills out of Range", nameof(config.ReddenOutOfRange));
+        configWindow.AddCategory(Strings("FadeUnavailableActions_CategoryFeatureToggles"))
+            .AddCheckbox(Strings("FadeUnavailableActions_LabelApplyToFrame"), nameof(config.ApplyToFrame))
+            .AddCheckbox(Strings("FadeUnavailableActions_LabelApplyToSync"), nameof(config.ApplyToSyncActions))
+            .AddCheckbox(Strings("FadeUnavailableActions_LabelReddenOutOfRange"), nameof(config.ReddenOutOfRange));
         
         OpenConfigAction = configWindow.Toggle;
 

--- a/VanillaPlus/Features/FastMouseClick/FastMouseClick.cs
+++ b/VanillaPlus/Features/FastMouseClick/FastMouseClick.cs
@@ -5,9 +5,8 @@ namespace VanillaPlus.Features.FastMouseClick;
 
 public class FastMouseClick : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Fast Mouse Click",
-        Description = "The game does not fire UI events for single mouse clicks whenever a double click is detected.\n\n" +
-                      "This game modification fixes it by always triggering the normal mouse click in addition to the double click.",
+        DisplayName = Strings("ModificationDisplay_FastMouseClick"),
+        Description = Strings("ModificationDescription_FastMouseClick"),
         Type = ModificationType.GameBehavior,
         Authors = ["Haselnussbomber"],
         ChangeLog = [

--- a/VanillaPlus/Features/FasterScroll/FasterScroll.cs
+++ b/VanillaPlus/Features/FasterScroll/FasterScroll.cs
@@ -9,8 +9,8 @@ namespace VanillaPlus.Features.FasterScroll;
 
 public unsafe class FasterScroll : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Faster Scrollbars",
-        Description = "Increases the speed of all scrollbars.",
+        DisplayName = Strings("ModificationDisplay_FasterScroll"),
+        Description = Strings("ModificationDescription_FasterScroll"),
         Authors = ["MidoriKami"],
         Type = ModificationType.GameBehavior,
         ChangeLog = [
@@ -25,15 +25,16 @@ public unsafe class FasterScroll : GameModification {
 
     public override void OnEnable() {
         config = FasterScrollConfig.Load();
+
         configWindow = new ConfigAddon {
             Size = new Vector2(400.0f, 125.0f),
             InternalName = "FasterScrollConfig",
-            Title = "Faster Scrollbars Config",
+            Title = Strings("FasterScroll_ConfigTitle"),
             Config = config,
         };
 
-        configWindow.AddCategory("Settings")
-            .AddFloatSlider("Speed Multiplier", 0.5f, 4.0f, 2, 0.05f, nameof(config.SpeedMultiplier));
+        configWindow.AddCategory(Strings("FasterScroll_CategorySettings"))
+            .AddFloatSlider(Strings("FasterScroll_LabelSpeedMultiplier"), 0.5f, 4.0f, 2, 0.05f, nameof(config.SpeedMultiplier));
         
         OpenConfigAction = configWindow.Toggle;
 

--- a/VanillaPlus/Features/FateListWindow/FateEntryNode.cs
+++ b/VanillaPlus/Features/FateListWindow/FateEntryNode.cs
@@ -111,10 +111,10 @@ public unsafe class FateEntryNode : SimpleComponentNode {
             timeRemainingNode.String = TimeSpan.FromSeconds(value.TimeRemaining).ToString(@"mm\:ss");
 
             if (Fate is not { Level: 1, MaxLevel: 255 }) {
-                levelNode.String = $"Lv. {value.Level}-{value.MaxLevel}";
+                levelNode.String = Strings("FateEntry_LevelRangeFormat", value.Level, value.MaxLevel);
             }
             else {
-                levelNode.String = "Lv. ???";
+                levelNode.String = Strings("FateEntry_LevelUnknown");
             }
            
             progressTextNode.String = $"{value.Progress}%";

--- a/VanillaPlus/Features/FateListWindow/FateListWindow.cs
+++ b/VanillaPlus/Features/FateListWindow/FateListWindow.cs
@@ -10,8 +10,8 @@ namespace VanillaPlus.Features.FateListWindow;
 
 public class FateListWindow : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Fate List Window",
-        Description = "Displays a list of all fates that are currently active in the current zone.",
+        DisplayName = Strings("ModificationDisplay_FateListWindow"),
+        Description = Strings("ModificationDescription_FateListWindow"),
         Type = ModificationType.NewWindow,
         Authors = ["MidoriKami"],
         ChangeLog = [
@@ -29,7 +29,7 @@ public class FateListWindow : GameModification {
         addonFateList = new NodeListAddon {
             Size = new Vector2(300.0f, 400.0f),
             InternalName = "FateList",
-            Title = "Fate List",
+            Title = Strings("FateListWindow_Title"),
             OpenCommand = "/fatelist",
             UpdateListFunction = UpdateList,
         };

--- a/VanillaPlus/Features/FocusTargetLock/FocusTargetLock.cs
+++ b/VanillaPlus/Features/FocusTargetLock/FocusTargetLock.cs
@@ -5,8 +5,8 @@ namespace VanillaPlus.Features.FocusTargetLock;
 
 public class FocusTargetLock : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Focus Target Lock",
-        Description = "When a duty recommences, restores your previous focus target.",
+        DisplayName = Strings("ModificationDisplay_FocusTargetLock"),
+        Description = Strings("ModificationDescription_FocusTargetLock"),
         Type = ModificationType.GameBehavior,
         Authors = [ "MidoriKami" ],
         ChangeLog = [

--- a/VanillaPlus/Features/ForcedCutsceneSounds/ForcedCutsceneSounds.cs
+++ b/VanillaPlus/Features/ForcedCutsceneSounds/ForcedCutsceneSounds.cs
@@ -12,8 +12,8 @@ namespace VanillaPlus.Features.ForcedCutsceneSounds;
 
 public unsafe class ForcedCutsceneSounds : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Forced Cutscene Sounds",
-        Description = "Automatically unmutes selected sound channels in cutscenes.",
+        DisplayName = Strings("ModificationDisplay_ForcedCutsceneSounds"),
+        Description = Strings("ModificationDescription_ForcedCutsceneSounds"),
         Authors = ["Haselnussbomber"],
         Type = ModificationType.GameBehavior,
         ChangeLog = [
@@ -47,27 +47,28 @@ public unsafe class ForcedCutsceneSounds : GameModification {
         wasMuted = [];
         
         config = ForcedCutsceneSoundsConfig.Load();
+
         configWindow = new ConfigAddon {
             Size = new Vector2(330.0f, 385.0f),
             InternalName = "ForcedCutsceneConfig",
-            Title = "Forced Cutscene Sounds Config",
+            Title = Strings("ForcedCutsceneSounds_ConfigTitle"),
             Config = config,
         };
 
-        configWindow.AddCategory("General")
-            .AddCheckbox("Restore Mute State After Cutscene", nameof(config.Restore));
+        configWindow.AddCategory(Strings("ForcedCutsceneSounds_CategoryGeneral"))
+            .AddCheckbox(Strings("ForcedCutsceneSounds_RestoreMuteState"), nameof(config.Restore));
 
-        configWindow.AddCategory("Toggles")
-            .AddCheckbox("Unmute Master Volume", nameof(config.HandleMaster))
-            .AddCheckbox("Unmute BGM", nameof(config.HandleBgm))
-            .AddCheckbox("Unmute Sound Effects", nameof(config.HandleSe))
-            .AddCheckbox("Unmute Voice", nameof(config.HandleVoice))
-            .AddCheckbox("Unmute Ambient Sounds", nameof(config.HandleEnv))
-            .AddCheckbox("Unmute System Sounds", nameof(config.HandleSystem))
-            .AddCheckbox("Unmute Performance", nameof(config.HandlePerform));
+        configWindow.AddCategory(Strings("ForcedCutsceneSounds_CategoryToggles"))
+            .AddCheckbox(Strings("ForcedCutsceneSounds_UnmuteMaster"), nameof(config.HandleMaster))
+            .AddCheckbox(Strings("ForcedCutsceneSounds_UnmuteBgm"), nameof(config.HandleBgm))
+            .AddCheckbox(Strings("ForcedCutsceneSounds_UnmuteSe"), nameof(config.HandleSe))
+            .AddCheckbox(Strings("ForcedCutsceneSounds_UnmuteVoice"), nameof(config.HandleVoice))
+            .AddCheckbox(Strings("ForcedCutsceneSounds_UnmuteEnv"), nameof(config.HandleEnv))
+            .AddCheckbox(Strings("ForcedCutsceneSounds_UnmuteSystem"), nameof(config.HandleSystem))
+            .AddCheckbox(Strings("ForcedCutsceneSounds_UnmutePerform"), nameof(config.HandlePerform));
 
-        configWindow.AddCategory("Special")
-            .AddCheckbox("Disable in MSQ Roulette", nameof(config.DisableInMsqRoulette));
+        configWindow.AddCategory(Strings("ForcedCutsceneSounds_CategorySpecial"))
+            .AddCheckbox(Strings("ForcedCutsceneSounds_DisableMsq"), nameof(config.DisableInMsqRoulette));
 
         OpenConfigAction = configWindow.Toggle;
         

--- a/VanillaPlus/Features/GearsetRedirect/GearsetInfo.cs
+++ b/VanillaPlus/Features/GearsetRedirect/GearsetInfo.cs
@@ -24,8 +24,8 @@ public unsafe class GearsetInfo : IInfoNodeData {
         => null;
 
     public int Compare(IInfoNodeData other, string sortingMode) => sortingMode switch {
-        "Alphabetical" => string.CompareOrdinal(GetLabel(), other.GetLabel()),
-        "Id" => GetId()?.CompareTo(other.GetId()) ?? 0,
+        var s when s == Strings("SortOption_Alphabetical") => string.CompareOrdinal(GetLabel(), other.GetLabel()),
+        var s when s == Strings("SortOption_Id") => GetId()?.CompareTo(other.GetId()) ?? 0,
         _ => 0,
     };
 

--- a/VanillaPlus/Features/GearsetRedirect/GearsetRedirect.cs
+++ b/VanillaPlus/Features/GearsetRedirect/GearsetRedirect.cs
@@ -9,8 +9,8 @@ namespace VanillaPlus.Features.GearsetRedirect;
 
 public unsafe class GearsetRedirect : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Gearset Redirect",
-        Description = "When equipping gearsets, set alternative sets to load depending on what zone you are in.",
+        DisplayName = Strings("ModificationDisplay_GearsetRedirect"),
+        Description = Strings("ModificationDescription_GearsetRedirect"),
         Type = ModificationType.GameBehavior,
         Authors = [ "MidoriKami" ],
         ChangeLog = [
@@ -31,7 +31,7 @@ public unsafe class GearsetRedirect : GameModification {
         configWindow = new GearsetRedirectConfigAddon {
             Size = new Vector2(600.0f, 525.0f),
             InternalName = "GearsetRedirectConfig",
-            Title = "Gearset Redirect Config",
+            Title = Strings("GearsetRedirect_ConfigTitle"),
             Config = config,
         };
 

--- a/VanillaPlus/Features/GearsetRedirect/GearsetRedirectConfigAddon.cs
+++ b/VanillaPlus/Features/GearsetRedirect/GearsetRedirectConfigAddon.cs
@@ -29,7 +29,7 @@ public unsafe class GearsetRedirectConfigAddon : NativeAddon {
     private readonly NewRedirectionAddon newRedirectionAddon = new() {
         Size = new Vector2(500.0f, 275.0f),
         InternalName = "AddRedirectionWindow",
-        Title = "Add New Gearset Redirection",
+        Title = Strings("GearsetRedirect_AddRedirectionTitle"),
     };
 
     public override void Dispose() {
@@ -44,7 +44,10 @@ public unsafe class GearsetRedirectConfigAddon : NativeAddon {
             Size = new Vector2(225.0f, ContentSize.Y),
             Position = ContentStartPosition,
             SelectionOptions = GetConfigInfos(),
-            SortOptions = [ "Alphabetical", "Id" ],
+            SortOptions = [
+                Strings("GearsetRedirect_SortAlphabetical"),
+                Strings("GearsetRedirect_SortId"),
+            ],
             AddNewEntry = OnAddEntry,
             RemoveEntry = OnRemoveEntry,
             OnOptionChanged = OnOptionChanged,

--- a/VanillaPlus/Features/GearsetRedirect/RedirectInfo.cs
+++ b/VanillaPlus/Features/GearsetRedirect/RedirectInfo.cs
@@ -24,8 +24,8 @@ public unsafe class RedirectInfo : IInfoNodeData {
         => null;
 
     public int Compare(IInfoNodeData other, string sortingMode) => sortingMode switch {
-        "Alphabetical" => string.CompareOrdinal(GetLabel(), other.GetLabel()),
-        "Id" => GetId()?.CompareTo(other.GetId()) ?? 0,
+        var s when s == Strings("SortOption_Alphabetical") => string.CompareOrdinal(GetLabel(), other.GetLabel()),
+        var s when s == Strings("SortOption_Id") => GetId()?.CompareTo(other.GetId()) ?? 0,
         _ => 0,
     };
     

--- a/VanillaPlus/Features/HUDCoordinates/HUDCoordinates.cs
+++ b/VanillaPlus/Features/HUDCoordinates/HUDCoordinates.cs
@@ -10,9 +10,8 @@ namespace VanillaPlus.Features.HUDCoordinates;
 
 public unsafe class HUDCoordinates : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "HUD Coordinates",
-        Description = "Display coordinate positions in HUD Layout nodes, allows you get get things exactly right.\n\n" +
-                      "Displays coordinates for the center of the HUD element.",
+        DisplayName = Strings("ModificationDisplay_HUDCoordinates"),
+        Description = Strings("ModificationDescription_HUDCoordinates"),
         Type = ModificationType.UserInterface,
         Authors = [ "MidoriKami" ],
         ChangeLog = [

--- a/VanillaPlus/Features/HUDPresets/HUDPreset.cs
+++ b/VanillaPlus/Features/HUDPresets/HUDPreset.cs
@@ -10,8 +10,8 @@ namespace VanillaPlus.Features.HUDPresets;
 
 public unsafe class HUDPresets : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "HUD Presets",
-        Description = "Allows you to save and load an unlimited number of HUD Layouts.",
+        DisplayName = Strings("ModificationDisplay_HUDPresets"),
+        Description = Strings("ModificationDescription_HUDPresets"),
         Type = ModificationType.UserInterface,
         Authors = [ "MidoriKami" ],
         ChangeLog = [
@@ -36,7 +36,7 @@ public unsafe class HUDPresets : GameModification {
         renameAddon = new RenameAddon {
             Size = new Vector2(250.0f, 150.0f),
             InternalName = "PresetNameWindow",
-            Title = "HUD Preset Name",
+            Title = Strings("HUDPresets_RenameTitle"),
             DepthLayer = 6,
         };
 
@@ -52,7 +52,7 @@ public unsafe class HUDPresets : GameModification {
                 FontType = FontType.Axis,
                 TextFlags = TextFlags.Emboss | TextFlags.AutoAdjustNodeSize,
                 TextColor = ColorHelper.GetColor(8),
-                String = "[VanillaPlus] HUD Presets",
+                String = Strings("HUDPresets_Label"),
             };
             labelNode.AttachNode(addon);
             
@@ -61,7 +61,7 @@ public unsafe class HUDPresets : GameModification {
                 Size = new Vector2(addon->Size.X - 32.0f, 24.0f),
                 MaxListOptions = 10,
                 Options = HUDPresetManager.GetPresetNames(),
-                TooltipString = "Select a HUD Layout Preset",
+                TooltipString = Strings("HUDPresets_DropdownTooltip"),
                 OnOptionSelected = UpdateButtonLocks,
             };
             presetDropdownNode.AttachNode(addon);
@@ -69,8 +69,8 @@ public unsafe class HUDPresets : GameModification {
             loadButtonNode = new TextButtonNode {
                 Position = new Vector2(32.0f, 269.0f),
                 Size = new Vector2(100.0f, 28.0f),
-                String = "Load",
-                TooltipString = "Load selected preset",
+                String = Strings("HUDPresets_ButtonLoad"),
+                TooltipString = Strings("HUDPresets_ButtonLoadTooltip"),
                 OnClick = LoadPreset,
                 IsEnabled = false,
             };
@@ -79,8 +79,8 @@ public unsafe class HUDPresets : GameModification {
             overwriteButtonNode = new TextButtonNode {
                 Position = new Vector2(144.0f, 269.0f),
                 Size = new Vector2(100.0f, 28.0f),
-                String = "Overwrite",
-                TooltipString = "Overwrite selected preset",
+                String = Strings("HUDPresets_ButtonOverwrite"),
+                TooltipString = Strings("HUDPresets_ButtonOverwriteTooltip"),
                 IsEnabled = false,
                 OnClick = OverwriteSelectedPreset,
             };
@@ -89,20 +89,21 @@ public unsafe class HUDPresets : GameModification {
             deleteButtonNode = new TextButtonNode {
                 Position = new Vector2(256.0f, 269.0f),
                 Size = new Vector2(100.0f, 28.0f),
-                String = "Delete",
+                String = Strings("HUDPresets_ButtonDelete"),
                 // TooltipString = "Delete selected preset",
                 IsEnabled = false,
                 // OnClick = DeleteSelectedPreset,
             };
-            deleteButtonNode.CollisionNode.TooltipString = "Work in Progress\nManually delete preset files for now";
+            deleteButtonNode.CollisionNode.TooltipString = Strings("HUDPresets_DeleteTooltip");
             deleteButtonNode.AttachNode(addon);
             
             saveButtonNode = new TextButtonNode {
                 Position = new Vector2(368.0f, 269.0f),
                 Size = new Vector2(100.0f, 28.0f),
-                String = "Save",
+                String = Strings("HUDPresets_ButtonSave"),
                 OnClick = SaveCurrentLayout,
             };
+            saveButtonNode.CollisionNode.TooltipString = Strings("HUDPresets_SaveTooltipEnabled");
             saveButtonNode.AttachNode(addon);
         };
 
@@ -136,10 +137,10 @@ public unsafe class HUDPresets : GameModification {
                         saveButtonNode.IsEnabled = !mainSaveButton->IsEnabled;
 
                         if (mainSaveButton->IsEnabled) {
-                            saveButtonNode.CollisionNode.TooltipString = "Click save above before saving a new preset";
+                            saveButtonNode.CollisionNode.TooltipString = Strings("HUDPresets_SaveTooltipDisabled");
                         }
                         else {
-                            saveButtonNode.CollisionNode.TooltipString = "Save Current UI as a new preset";
+                            saveButtonNode.CollisionNode.TooltipString = Strings("HUDPresets_SaveTooltipEnabled");
                         }
                     }
                 }
@@ -173,7 +174,7 @@ public unsafe class HUDPresets : GameModification {
     private void SaveCurrentLayout() {
         if (renameAddon is null) return;
 
-        renameAddon.PlaceholderString = "New Preset Name";
+        renameAddon.PlaceholderString = Strings("HUDPresets_PlaceholderNewPreset");
         renameAddon.DefaultString = string.Empty;
         renameAddon.OnRenameComplete = newName => {
             HUDPresetManager.SavePreset(newName);

--- a/VanillaPlus/Features/HUDPresets/HUDPresetManager.cs
+++ b/VanillaPlus/Features/HUDPresets/HUDPresetManager.cs
@@ -10,7 +10,7 @@ using VanillaPlus.Utilities;
 namespace VanillaPlus.Features.HUDPresets;
 
 public static unsafe class HUDPresetManager {
-    public const string DefaultOption = "No Option Selected";
+    public static string DefaultOption => Strings("HUDPresets_DefaultOption");
 
     public static List<string> GetPresetNames() {
         var directory = GetPresetDirectory();

--- a/VanillaPlus/Features/HideGuildhestObjectivePopup/HideGuildhestObjectivePopup.cs
+++ b/VanillaPlus/Features/HideGuildhestObjectivePopup/HideGuildhestObjectivePopup.cs
@@ -8,9 +8,8 @@ namespace VanillaPlus.Features.HideGuildhestObjectivePopup;
 
 public class HideGuildhestObjectivePopup : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Hide Guildhest Objective Popup",
-        Description = "When starting a guildhest this modification will prevent the popup window that contains the instructions on how to do the Guildhest.\n\n" +
-                      "This feature is not recommended if this is your first time doing Guildhests.",
+        DisplayName = Strings("ModificationDisplay_HideGuildhestObjectivePopup"),
+        Description = Strings("ModificationDescription_HideGuildhestObjectivePopup"),
         Authors = ["MidoriKami"],
         Type = ModificationType.GameBehavior,
         ChangeLog = [

--- a/VanillaPlus/Features/HideMpBars/HideMpBars.cs
+++ b/VanillaPlus/Features/HideMpBars/HideMpBars.cs
@@ -11,8 +11,8 @@ namespace VanillaPlus.Features.HideMpBars;
 
 public unsafe class HideMpBars : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Hide MP Bars",
-        Description = "Hides MP Bars in party list for jobs that don't use MP.",
+        DisplayName = Strings("ModificationDisplay_HideMpBars"),
+        Description = Strings("ModificationDescription_HideMpBars"),
         Type = ModificationType.UserInterface,
         Authors = [ "MidoriKami" ],
         ChangeLog = [

--- a/VanillaPlus/Features/HideUnwantedBanners/HideUnwantedBanners.cs
+++ b/VanillaPlus/Features/HideUnwantedBanners/HideUnwantedBanners.cs
@@ -11,8 +11,8 @@ namespace VanillaPlus.Features.HideUnwantedBanners;
 
 public unsafe class HideUnwantedBanners : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Hide Unwanted Banners",
-        Description = "Prevents large text banners from appearing and playing their sound effect.",
+        DisplayName = Strings("ModificationDisplay_HideUnwantedBanners"),
+        Description = Strings("ModificationDescription_HideUnwantedBanners"),
         Authors = ["MidoriKami"],
         Type = ModificationType.GameBehavior,
         ChangeLog = [
@@ -33,7 +33,7 @@ public unsafe class HideUnwantedBanners : GameModification {
 
         configWindow = new NodeListAddon {
             InternalName = "BannersConfig",
-            Title = "Hide Unwanted Banners Config",
+            Title = Strings("HideUnwantedBanners_ConfigTitle"),
             Size = new Vector2(500.0f, 600.0f),
             UpdateListFunction = UpdateList,
         };

--- a/VanillaPlus/Features/InstancedWaymarks/InstancedWaymarks.cs
+++ b/VanillaPlus/Features/InstancedWaymarks/InstancedWaymarks.cs
@@ -22,8 +22,8 @@ namespace VanillaPlus.Features.InstancedWaymarks;
 
 public unsafe class InstancedWaymarks : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Instanced Waymarks",
-        Description = "Enables the use of all saved Waymark Slots per duty, instead of sharing them across all duties, with the option to name each slot.",
+        DisplayName = Strings("ModificationDisplay_InstancedWaymarks"),
+        Description = Strings("ModificationDescription_InstancedWaymarks"),
         Type = ModificationType.GameBehavior,
         Authors = [ "MidoriKami" ],
         ChangeLog = [
@@ -45,7 +45,7 @@ public unsafe class InstancedWaymarks : GameModification {
         renameWindow ??= new RenameAddon {
             Size = new Vector2(250.0f, 150.0f),
             InternalName = "WaymarkRename",
-            Title = "Waymark Rename Window",
+            Title = Strings("InstancedWaymarks_RenameWindowTitle"),
             AutoSelectAll = true,
         };
         
@@ -91,7 +91,7 @@ public unsafe class InstancedWaymarks : GameModification {
         ref var slotMarkerData = ref FieldMarkerModule.Instance()->Presets[slotClicked];
 
         args.AddMenuItem(new MenuItem {
-            Name = "Rename",
+            Name = Strings("InstancedWaymarks_RenameMenuLabel"),
             OnClicked = RenameContextMenuAction,
             UseDefaultPrefix = true,
             IsEnabled =

--- a/VanillaPlus/Features/InventorySearchBar/InventorySearchBar.cs
+++ b/VanillaPlus/Features/InventorySearchBar/InventorySearchBar.cs
@@ -4,8 +4,8 @@ namespace VanillaPlus.Features.InventorySearchBar;
 
 public class InventorySearchBar : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Inventory Search Bar",
-        Description = "Adds a search bar to the inventory window.",
+        DisplayName = Strings("ModificationDisplay_InventorySearchBar"),
+        Description = Strings("ModificationDescription_InventorySearchBar"),
         Type = ModificationType.UserInterface,
         SubType = ModificationSubType.Inventory,
         Authors = [ "MidoriKami" ],

--- a/VanillaPlus/Features/ListInventory/ListInventory.cs
+++ b/VanillaPlus/Features/ListInventory/ListInventory.cs
@@ -11,8 +11,8 @@ namespace VanillaPlus.Features.ListInventory;
 
 public class ListInventory : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Inventory List Window",
-        Description = "Adds a window that displays your inventory as a list, with toggleable filters.",
+        DisplayName = Strings("ModificationDisplay_ListInventory"),
+        Description = Strings("ModificationDescription_ListInventory"),
         Type = ModificationType.NewWindow,
         Authors = [ "MidoriKami" ],
         ChangeLog = [
@@ -30,18 +30,33 @@ public class ListInventory : GameModification {
     private string searchString = string.Empty;
     private bool filterReversed;
     private bool updateRequested;
+    private static string filterAlphabeticallyLabel => Strings("ListInventory_FilterAlphabetically");
+    private static string filterQuantityLabel => Strings("ListInventory_FilterQuantity");
+    private static string filterLevelLabel => Strings("ListInventory_FilterLevel");
+    private static string filterItemLevelLabel => Strings("ListInventory_FilterItemLevel");
+    private static string filterRarityLabel => Strings("ListInventory_FilterRarity");
+    private static string filterItemIdLabel => Strings("ListInventory_FilterItemId");
+    private static string filterItemCategoryLabel => Strings("ListInventory_FilterItemCategory");
 
     public override string ImageName => "ListInventory.png";
 
     public override void OnEnable() {
         addonListInventory = new SearchableNodeListAddon {
             InternalName = "ListInventory",
-            Title = "Inventory List",
+            Title = Strings("ListInventory_Title"),
             Size = new Vector2(450.0f, 700.0f),
             OnFilterUpdated = OnFilterUpdated,
             OnSearchUpdated = OnSearchUpdated,
             UpdateListFunction = OnListUpdated,
-            DropDownOptions = ["Alphabetically", "Quantity", "Level", "Item Level", "Rarity", "Item Id", "Item Category"],
+            DropDownOptions = [
+                filterAlphabeticallyLabel,
+                filterQuantityLabel,
+                filterLevelLabel,
+                filterItemLevelLabel,
+                filterRarityLabel,
+                filterItemIdLabel,
+                filterItemCategoryLabel,
+            ],
             OpenCommand = "/listinventory",
         };
 
@@ -105,13 +120,13 @@ public class ListInventory : GameModification {
         // Note: Compares in opposite direction to be descending instead of ascending, except for alphabetically
 
         var result = filterString switch {
-            "Alphabetically" => string.CompareOrdinal(leftItem.Name, rightItem.Name),
-            "Level" => rightItem.Level.CompareTo(leftItem.Level),
-            "Item Level" => rightItem.ItemLevel.CompareTo(leftItem.ItemLevel),
-            "Rarity" => rightItem.Rarity.CompareTo(leftItem.Rarity),
-            "Item Id" => rightItem.Item.ItemId.CompareTo(leftItem.Item.ItemId),
-            "Item Category" => rightItem.UiCategory.CompareTo(leftItem.UiCategory),
-            "Quantity" => rightItem.ItemCount.CompareTo(leftItem.ItemCount),
+            var s when s == filterAlphabeticallyLabel  => string.CompareOrdinal(leftItem.Name, rightItem.Name),
+            var s when s == filterLevelLabel => rightItem.Level.CompareTo(leftItem.Level),
+            var s when s == filterItemLevelLabel  => rightItem.ItemLevel.CompareTo(leftItem.ItemLevel),
+            var s when s == filterRarityLabel  => rightItem.Rarity.CompareTo(leftItem.Rarity),
+            var s when s == filterItemIdLabel => rightItem.Item.ItemId.CompareTo(leftItem.Item.ItemId),
+            var s when s == filterItemCategoryLabel => rightItem.UiCategory.CompareTo(leftItem.UiCategory),
+            var s when s == filterQuantityLabel => rightItem.ItemCount.CompareTo(leftItem.ItemCount),
             _ => string.CompareOrdinal(leftItem.Name, rightItem.Name),
         };
 

--- a/VanillaPlus/Features/LocationDisplay/LocationDisplay.cs
+++ b/VanillaPlus/Features/LocationDisplay/LocationDisplay.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using Dalamud.Game.Gui.Dtr;
 using Dalamud.Game.Text;
 using Dalamud.Plugin.Services;
@@ -13,8 +14,8 @@ namespace VanillaPlus.Features.LocationDisplay;
 
 public unsafe class LocationDisplay : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Location Display",
-        Description = "Displays your current location in the server information bar.",
+        DisplayName = Strings("ModificationDisplay_LocationDisplay"),
+        Description = Strings("ModificationDescription_LocationDisplay"),
         Authors = [ "MidoriKami" ],
         Type = ModificationType.UserInterface,
         ChangeLog = [
@@ -53,7 +54,7 @@ public unsafe class LocationDisplay : GameModification {
 
         configWindow = new LocationDisplayConfigAddon {
             InternalName = "LocationDisplayConfig",
-            Title = "Location Display Config",
+            Title = Strings("LocationDisplay_ConfigTitle"),
             Config = config,
         };
 
@@ -61,7 +62,7 @@ public unsafe class LocationDisplay : GameModification {
 
         OpenConfigAction = configWindow.Toggle;
         
-        dtrBarEntry = Services.DtrBar.Get("VanillaPlus - LocationDisplay");
+        dtrBarEntry = Services.DtrBar.Get(Strings("LocationDisplay_DtrEntryName"));
         dtrBarEntry.OnClick = _ => configWindow.Toggle();
 
         locationChanged = true;
@@ -218,7 +219,7 @@ public unsafe class LocationDisplay : GameModification {
 
 		if (lastHousingWard != ward) {
 			lastHousingWard = ward;
-			currentWard = $"Ward {ward}";
+			currentWard = Strings("LocationDisplay_WardFormat", ward);
 			locationChanged = true;
 		}
 	}
@@ -256,18 +257,21 @@ public unsafe class LocationDisplay : GameModification {
 		var room = housingManager->GetCurrentRoom();
 		var division = housingManager->GetCurrentDivision();
 
-		strings.Add($"Ward {ward}");
-		if (division == 2 || plot is >= 30 or -127) strings.Add($"Subdivision");
+		strings.Add(Strings("LocationDisplay_WardFormat", ward));
+		if (division == 2 || plot is >= 30 or -127) strings.Add(Strings("LocationDisplay_SubdivisionLabel"));
 
 		switch (plot) {
 			case < -1:
-				strings.Add($"Apartment {(room == 0 ? $"Lobby" : $"{room}")}");
+				var apartmentValue = room == 0
+					? Strings("LocationDisplay_ApartmentFormat", Strings("LocationDisplay_ApartmentLobby"))
+					: Strings("LocationDisplay_ApartmentFormat", room);
+				strings.Add(apartmentValue);
 				break;
 
 			case > -1:
-				strings.Add($"Plot {plot + 1}");
+				strings.Add(Strings("LocationDisplay_PlotFormat", plot + 1));
 				if (room > 0) {
-					strings.Add($"Room {room}");
+					strings.Add(Strings("LocationDisplay_RoomFormat", room));
 				}
 				break;
 		}

--- a/VanillaPlus/Features/LocationDisplay/LocationDisplayConfigAddon.cs
+++ b/VanillaPlus/Features/LocationDisplay/LocationDisplayConfigAddon.cs
@@ -33,13 +33,7 @@ public class LocationDisplayConfigAddon : NativeAddon {
             Size = new Vector2(ContentSize.X, 150.0f),
             LineSpacing = 16,
             TextFlags = TextFlags.MultiLine,
-            String = "Use the text box below to define how you want the text to be formatted.\n" +
-                     "Use symbols {0} {1} {2} {3} {4} where you want the following values to be in the string\n\n" +
-                     "{0} - Region (Ex. The Northern Empty)\n" +
-                     "{1} - Territory (Ex. Old Sharlayan)\n" +
-                     "{2} - Area (Ex. Archons Design)\n" +
-                     "{3} - Sub-Area (Ex. Old Sharlayan Aetheryte Plaza)\n" +
-                     "{4} - Housing Ward (Ex. Ward 14)",
+            String = Strings("Label_LocationDisplayInstructions"),
         };
         instructionTextNode.AttachNode(this);
 
@@ -51,7 +45,7 @@ public class LocationDisplayConfigAddon : NativeAddon {
 
         entryLabelNode = new TextNode {
             Size = new Vector2(125.0f, 30.0f),
-            String = "Info Bar Entry",
+            String = Strings("LocationDisplay_InfoBarEntryLabel"),
             AlignmentType = AlignmentType.Left,
         };
         infoBarEntryLayoutNode.AddNode(entryLabelNode);
@@ -74,11 +68,11 @@ public class LocationDisplayConfigAddon : NativeAddon {
 
         resetEntryButtonNode = new TextButtonNode {
             Size = new Vector2(125.0f, 30.0f),
-            String = "Reset to Default",
+            String = Strings("LocationDisplay_ResetButton"),
             OnClick = () => {
                 entryInputNode.IsError = false;
-                entryInputNode.String = "{0}, {1}, {2}, {3}";
-                Config.FormatString = "{0}, {1}, {2}, {3}";
+                entryInputNode.String = Strings("LocationDisplay_DefaultEntryFormat");
+                Config.FormatString = Strings("LocationDisplay_DefaultEntryFormat");
                 Config.Save();
             },
         };
@@ -92,7 +86,7 @@ public class LocationDisplayConfigAddon : NativeAddon {
 
         tooltipLabelNode = new TextNode {
             Size = new Vector2(125.0f, 30.0f),
-            String = "Info Bar Tooltip",
+            String = Strings("LocationDisplay_InfoBarTooltipLabel"),
             AlignmentType = AlignmentType.Left,
         };
         infoBarTooltipLayoutNode.AddNode(tooltipLabelNode);
@@ -115,11 +109,11 @@ public class LocationDisplayConfigAddon : NativeAddon {
 
         tooltipResetButtonNode = new TextButtonNode {
             Size = new Vector2(125.0f, 30.0f),
-            String = "Reset to Default",
+            String = Strings("LocationDisplay_ResetButton"),
             OnClick = () => {
                 tooltipInputNode.IsError = false;
-                tooltipInputNode.String = "{0}, {1}, {2}, {3}";
-                Config.TooltipFormatString = "{0}, {1}, {2}, {3}";
+                tooltipInputNode.String = Strings("LocationDisplay_DefaultTooltipFormat");
+                Config.TooltipFormatString = Strings("LocationDisplay_DefaultTooltipFormat");
                 Config.Save();
             },
         };
@@ -128,7 +122,7 @@ public class LocationDisplayConfigAddon : NativeAddon {
         showInstanceNumberNode = new CheckboxNode {
             Size = new Vector2(ContentSize.X, 24.0f),
             Position = new Vector2(ContentStartPosition.X, infoBarTooltipLayoutNode.Y + infoBarTooltipLayoutNode.Height + 15.0f),
-            String = "Show Instance Number",
+            String = Strings("LocationDisplay_ShowInstanceNumber"),
             IsChecked = Config.ShowInstanceNumber,
             OnClick = newValue => {
                 Config.ShowInstanceNumber = newValue;
@@ -140,7 +134,7 @@ public class LocationDisplayConfigAddon : NativeAddon {
         showPreciseHousingLocationNode = new CheckboxNode {
             Size = new Vector2(ContentSize.X, 24.0f),
             Position = new Vector2(ContentStartPosition.X, showInstanceNumberNode.Y + showInstanceNumberNode.Height),
-            String = "Show Precise Housing Location",
+            String = Strings("LocationDisplay_ShowPreciseHousing"),
             IsChecked = Config.UsePreciseHousingLocation,
             OnClick = newValue => {
                 Config.UsePreciseHousingLocation = newValue;

--- a/VanillaPlus/Features/MacroLineNumbers/MacroLineNumbers.cs
+++ b/VanillaPlus/Features/MacroLineNumbers/MacroLineNumbers.cs
@@ -10,8 +10,8 @@ namespace VanillaPlus.Features.MacroLineNumbers;
 
 public unsafe class MacroLineNumbers : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Macro Line Numbers",
-        Description = "Adds line numbers to the User Macros window.",
+        DisplayName = Strings("ModificationDisplay_MacroLineNumbers"),
+        Description = Strings("ModificationDescription_MacroLineNumbers"),
         Type = ModificationType.UserInterface,
         Authors = [ "MidoriKami" ],
         ChangeLog = [

--- a/VanillaPlus/Features/MacroTooltips/MacroTooltips.cs
+++ b/VanillaPlus/Features/MacroTooltips/MacroTooltips.cs
@@ -12,8 +12,8 @@ namespace VanillaPlus.Features.MacroTooltips;
 /// </summary>
 public unsafe class MacroTooltips : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Macro Tooltips",
-        Description = "Displays action tooltips when hovering over a macro with '/macroicon' set with an 'action'.",
+        DisplayName = Strings("ModificationDisplay_MacroTooltips"),
+        Description = Strings("ModificationDescription_MacroTooltips"),
         Type = ModificationType.UserInterface,
         Authors = [ "MidoriKami" ],
         ChangeLog = [

--- a/VanillaPlus/Features/MiniCactpotHelper/MiniCactpotHelper.cs
+++ b/VanillaPlus/Features/MiniCactpotHelper/MiniCactpotHelper.cs
@@ -15,8 +15,8 @@ namespace VanillaPlus.Features.MiniCactpotHelper;
 
 public unsafe class MiniCactpotHelper : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Mini Cactpot Helper",
-        Description = "Indicates which Mini Cactpot spots you should reveal next.",
+        DisplayName = Strings("ModificationDisplay_MiniCactpotHelper"),
+        Description = Strings("ModificationDescription_MiniCactpotHelper"),
         Authors = ["MidoriKami"],
         Type = ModificationType.UserInterface,
         ChangeLog = [
@@ -47,19 +47,19 @@ public unsafe class MiniCactpotHelper : GameModification {
 
         configWindow = new ConfigAddon {
             InternalName = "MiniCactpotConfig",
-            Title = "Mini Cactpot Helper Config",
+            Title = Strings("Title_MiniCactpotConfig"),
             Config = config,
         };
 
-        configWindow.AddCategory("Animations")
-            .AddCheckbox("Enable Animations", nameof(config.EnableAnimations));
+        configWindow.AddCategory(Strings("ConfigCategory_Animations"))
+            .AddCheckbox(Strings("ConfigLabel_EnableAnimations"), nameof(config.EnableAnimations));
 
-        configWindow.AddCategory("Icon")
-            .AddMultiSelectIcon("Icon", nameof(config.IconId), true, 61332, 90452, 234008);
+        configWindow.AddCategory(Strings("ConfigCategory_Icon"))
+            .AddMultiSelectIcon(Strings("ConfigLabel_Icon"), nameof(config.IconId), true, 61332, 90452, 234008);
 
-        configWindow.AddCategory("Colors")
-            .AddColorEdit("Button", nameof(config.ButtonColor), KnownColor.White.Vector() with { W = 0.8f })
-            .AddColorEdit("Lane", nameof(config.LaneColor), KnownColor.White.Vector());
+        configWindow.AddCategory(Strings("ConfigCategory_Colors"))
+            .AddColorEdit(Strings("ConfigLabel_ButtonColor"), nameof(config.ButtonColor), KnownColor.White.Vector() with { W = 0.8f })
+            .AddColorEdit(Strings("ConfigLabel_LaneColor"), nameof(config.LaneColor), KnownColor.White.Vector());
 
         config.OnSave += ApplyConfigStyle;
 
@@ -103,11 +103,11 @@ public unsafe class MiniCactpotHelper : GameModification {
 		};
 		gameGrid.AttachNode(buttonContainerNode);
 
-		configButton = new CircleButtonNode {
+        configButton = new CircleButtonNode {
 			Position = new Vector2(8.0f, 8.0f),
 			Size = new Vector2(32.0f, 32.0f),
 			Icon = ButtonIcon.GearCog,
-			Tooltip = "Configure EzMiniCactpot Plugin",
+            Tooltip = Strings("Tooltip_ConfigEzMiniCactpot"),
 			OnClick = () => configWindow.Toggle(),
 		};
 		configButton.AttachNode(buttonContainerNode);

--- a/VanillaPlus/Features/MissingJobStoneLockout/MissingJobStoneLockout.cs
+++ b/VanillaPlus/Features/MissingJobStoneLockout/MissingJobStoneLockout.cs
@@ -15,8 +15,8 @@ namespace VanillaPlus.Features.MissingJobStoneLockout;
 
 public unsafe class MissingJobStoneLockout : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Missing Job Stone Lockout",
-        Description = "Prevents queuing for a duty while you are missing a jobstone.",
+        DisplayName = Strings("ModificationDisplay_MissingJobStoneLockout"),
+        Description = Strings("ModificationDescription_MissingJobStoneLockout"),
         Type = ModificationType.UserInterface,
         Authors = [ "MidoriKami", "KazWolfe" ],
         ChangeLog = [
@@ -67,8 +67,8 @@ public unsafe class MissingJobStoneLockout : GameModification {
             Origin = newNodeSize / 2.0f,
             AlignmentType = AlignmentType.Center,
             FontSize = 14,
-            String = "Missing Job Stone!",
-            TooltipString = "[VanillaPlus]: Click to disable lock",
+            String = Strings("MissingJobStone_WarningText"),
+            TooltipString = Strings("MissingJobStone_Tooltip"),
             DrawFlags = DrawFlags.ClickableCursor,
         };
         warningTextNode.AttachNode(animationContainer);
@@ -96,7 +96,7 @@ public unsafe class MissingJobStoneLockout : GameModification {
                 animationContainer.IsVisible = false;
             }
 
-            warningTextNode.TooltipString = $"[VanillaPlus]: Click to disable lock\n{6 - clickCount} Clicks remaining";
+            warningTextNode.TooltipString = Strings("MissingJobStone_TooltipWithCountdown", 6 - clickCount);
             warningTextNode.ShowTooltip();
         });
     }

--- a/VanillaPlus/Features/OpenGlamourDresserToCurrentJob/OpenGlamourDresserToCurrentJob.cs
+++ b/VanillaPlus/Features/OpenGlamourDresserToCurrentJob/OpenGlamourDresserToCurrentJob.cs
@@ -7,8 +7,8 @@ namespace VanillaPlus.Features.OpenGlamourDresserToCurrentJob;
 
 public class OpenGlamourDresserToCurrentJob : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Open Glamour Dresser to Current Job",
-        Description = "When opening the glamour dresser, the tab for your current job will be automatically selected.",
+        DisplayName = Strings("ModificationDisplay_OpenGlamourDresserToCurrentJob"),
+        Description = Strings("ModificationDescription_OpenGlamourDresserToCurrentJob"),
         Type = ModificationType.GameBehavior,
         Authors = ["MidoriKami"],
         ChangeLog = [

--- a/VanillaPlus/Features/PartyFinderPresets/PartyFinderPresets.cs
+++ b/VanillaPlus/Features/PartyFinderPresets/PartyFinderPresets.cs
@@ -14,8 +14,8 @@ namespace VanillaPlus.Features.PartyFinderPresets;
 
 public unsafe class PartyFinderPresets : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Party Finder Presets",
-        Description = "Allows you to save an use presets for the Party Finder Recruitment window.",
+        DisplayName = Strings("ModificationDisplay_PartyFinderPresets"),
+        Description = Strings("ModificationDescription_PartyFinderPresets"),
         Type = ModificationType.GameBehavior,
         Authors = [ "MidoriKami" ],
         ChangeLog = [
@@ -40,7 +40,7 @@ public unsafe class PartyFinderPresets : GameModification {
         presetEditorAddon = new ListConfigAddon<PresetInfo, PartyFinderPresetConfigNode> {
             Size = new Vector2(600.0f, 400.0f),
             InternalName = "PresetConfigManager",
-            Title = "Preset Config Manager",
+            Title = Strings("Title_PresetConfigManager"),
             Options = GetPresetInfos(),
             OnConfigChanged = _ => {
                 UpdateDropDownOptions();
@@ -53,7 +53,7 @@ public unsafe class PartyFinderPresets : GameModification {
 
         savePresetWindow = new RenameAddon {
             InternalName = "PartyFinderPresetRename",
-            Title = "Party Finder Preset",
+            Title = Strings("Title_PartyFinderPreset"),
             IsInputValid = PresetManager.IsValidFileName,
             OnRenameComplete = newOption => {
                 PresetManager.SavePreset(newOption);
@@ -71,8 +71,8 @@ public unsafe class PartyFinderPresets : GameModification {
             savePresetButton = new TextButtonNode {
                 Position = new Vector2(406.0f, 605.0f),
                 Size = new Vector2(160.0f, 28.0f),
-                String = "Save Preset",
-                Tooltip = "[VanillaPlus]: Save current settings to a preset",
+                String = Strings("Button_SavePreset"),
+                Tooltip = Strings("Tooltip_SavePreset"),
                 OnClick = savePresetWindow.Open,
             };
             savePresetButton.AttachNode(addon);
@@ -136,8 +136,8 @@ public unsafe class PartyFinderPresets : GameModification {
         if ((AtkEventType)eventArgs.AtkEventType is not AtkEventType.ButtonClick) return;
         if (eventArgs.EventParam is not 2) return;
         if (presetDropDown?.SelectedOption is not { } selectedOption) return;
-        if (selectedOption is PresetManager.DefaultString) return;
-        if (selectedOption is PresetManager.DontUseString) return;
+        if (selectedOption == PresetManager.DefaultString) return;
+        if (selectedOption == PresetManager.DontUseString) return;
         
         PresetManager.LoadPreset(selectedOption);
     }
@@ -150,12 +150,9 @@ public unsafe class PartyFinderPresets : GameModification {
             presetDropDown.Options = presets;
             presetDropDown.IsEnabled = anyPresets;
 
-            if (anyPresets) {
-                presetDropDown.Tooltip = "[VanillaPlus]: Select a preset";
-            }
-            else {
-                presetDropDown.Tooltip = "[VanillaPlus]: No presets saved";
-            }
+            presetDropDown.Tooltip = anyPresets
+                ? Strings("Tooltip_SelectPreset")
+                : Strings("Tooltip_NoPresets");
         }
     }
 

--- a/VanillaPlus/Features/PartyFinderPresets/PresetManager.cs
+++ b/VanillaPlus/Features/PartyFinderPresets/PresetManager.cs
@@ -10,8 +10,8 @@ using VanillaPlus.Utilities;
 namespace VanillaPlus.Features.PartyFinderPresets;
 
 public static unsafe class PresetManager {
-    public const string DefaultString = "No Presets Saved";
-    public const string DontUseString = "Don't Use Preset";
+    public static string DefaultString => Strings("Preset_DefaultOption");
+    public static string DontUseString => Strings("Preset_DontUseOption");
 
     public static List<string> GetPresetNames() {
         var directory = GetPresetDirectory();

--- a/VanillaPlus/Features/PetSizeContextMenu/PetSizeContextMenu.cs
+++ b/VanillaPlus/Features/PetSizeContextMenu/PetSizeContextMenu.cs
@@ -7,8 +7,8 @@ namespace VanillaPlus.Features.PetSizeContextMenu;
 
 public class PetSizeContextMenu : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Pet Size Context Menu",
-        Description = "When right clicking on a pet, or a player with a pet, show a context menu entry for changing the pet size.",
+        DisplayName = Strings("ModificationDisplay_PetSizeContextMenu"),
+        Description = Strings("ModificationDescription_PetSizeContextMenu"),
         Authors = [ "MidoriKami" ],
         Type = ModificationType.GameBehavior,
         ChangeLog = [
@@ -39,25 +39,25 @@ public class PetSizeContextMenu : GameModification {
         args.AddMenuItem(new MenuItem {
             IsSubmenu = true,
             UseDefaultPrefix = true,
-            Name = "Pet Size",
+            Name = Strings("PetSize_MenuTitle"),
             OnClicked = clickedArgs => {
                 clickedArgs.OpenSubmenu([
                     new MenuItem {
                         IsEnabled = currentPetSize is not 0,
                         UseDefaultPrefix = true, 
-                        Name = "Small", 
+                        Name = Strings("PetSize_OptionSmall"), 
                         OnClicked = _ => SetPetSize(0),
                     },
                     new MenuItem {
                         IsEnabled = currentPetSize is not 1,
                         UseDefaultPrefix = true, 
-                        Name = "Medium", 
+                        Name = Strings("PetSize_OptionMedium"), 
                         OnClicked = _ => SetPetSize(1),
                     },
                     new MenuItem {
                         IsEnabled = currentPetSize is not 2,
                         UseDefaultPrefix = true, 
-                        Name = "Large", 
+                        Name = Strings("PetSize_OptionLarge"), 
                         OnClicked = _ => SetPetSize(2),
                     },
                 ]);

--- a/VanillaPlus/Features/QuestListWindow/QuestListWindow.cs
+++ b/VanillaPlus/Features/QuestListWindow/QuestListWindow.cs
@@ -12,8 +12,8 @@ namespace VanillaPlus.Features.QuestListWindow;
 
 public unsafe class QuestListWindow : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Quest List Window",
-        Description = "Displays a list of all available quests for the currently occupied zone.",
+        DisplayName = Strings("ModificationDisplay_QuestListWindow"),
+        Description = Strings("ModificationDescription_QuestListWindow"),
         Type = ModificationType.NewWindow,
         Authors = [ "MidoriKami" ],
         ChangeLog = [
@@ -27,15 +27,20 @@ public unsafe class QuestListWindow : GameModification {
     private bool filterReversed;
     private bool updateRequested;
 
+    private static string filterTypeLabel => Strings("QuestListWindow_FilterType");
+    private static string filterAlphabeticallyLabel => Strings("QuestListWindow_FilterAlphabetically");
+    private static string filterLevelLabel => Strings("QuestListWindow_FilterLevel");
+    private static string filterDistanceLabel => Strings("QuestListWindow_FilterDistance");
+    private static string filterIssuerNameLabel => Strings("QuestListWindow_FilterIssuerName");
     public override string ImageName => "QuestList.png";
 
     public override void OnEnable() {
         addonQuestList = new SearchableNodeListAddon {
             Size = new Vector2(300.0f, 400.0f),
             InternalName = "QuestList",
-            Title = "Quest List",
+            Title = Strings("QuestListWindow_Title"),
             UpdateListFunction = UpdateList,
-            DropDownOptions = [ "Type", "Alphabetically", "Level", "Distance", "Issuer Name", ],
+            DropDownOptions = [ filterTypeLabel, filterAlphabeticallyLabel, filterLevelLabel, filterDistanceLabel, filterIssuerNameLabel ],
             OnFilterUpdated = OnFilterUpdated,
             OnSearchUpdated = OnSearchUpdated,
             OpenCommand = "/questlist",
@@ -43,7 +48,7 @@ public unsafe class QuestListWindow : GameModification {
 
         addonQuestList.Initialize();
         
-        OnFilterUpdated("Type", false);
+        OnFilterUpdated(filterTypeLabel, false);
 
         OpenConfigAction = addonQuestList.OpenAddonConfig;
     }
@@ -76,7 +81,7 @@ public unsafe class QuestListWindow : GameModification {
             QuestInfo = data,
         });
 
-        if (listUpdated || updateRequested || filterString is "Distance") {
+        if (listUpdated || updateRequested || filterString == filterDistanceLabel) {
             listNode.ReorderNodes(Comparison);
         }
 
@@ -95,11 +100,11 @@ public unsafe class QuestListWindow : GameModification {
         var rightQuest = right.QuestInfo;
 
         var result = filterString switch {
-            "Alphabetically" => string.CompareOrdinal(leftQuest.Name.ToString(), rightQuest.Name.ToString()),
-            "Type" => rightQuest.IconId.CompareTo(leftQuest.IconId),
-            "Level" => rightQuest.Level.CompareTo(leftQuest.Level),
-            "Distance" => leftQuest.Distance.CompareTo(rightQuest.Distance),
-            "Issuer Name" => string.CompareOrdinal(leftQuest.IssuerName.ToString(), rightQuest.IssuerName.ToString()),
+            var s when s == filterAlphabeticallyLabel => string.CompareOrdinal(leftQuest.Name.ToString(), rightQuest.Name.ToString()),
+            var s when s == filterTypeLabel => rightQuest.IconId.CompareTo(leftQuest.IconId),
+            var s when s == filterLevelLabel => rightQuest.Level.CompareTo(leftQuest.Level),
+            var s when s == filterDistanceLabel => leftQuest.Distance.CompareTo(rightQuest.Distance),
+            var s when s == filterIssuerNameLabel => string.CompareOrdinal(leftQuest.IssuerName.ToString(), rightQuest.IssuerName.ToString()),
             _ => string.CompareOrdinal(leftQuest.Name.ToString(), rightQuest.Name.ToString()),
         };
 

--- a/VanillaPlus/Features/RecentlyLootedWindow/RecentlyLootedWindow.cs
+++ b/VanillaPlus/Features/RecentlyLootedWindow/RecentlyLootedWindow.cs
@@ -12,9 +12,8 @@ namespace VanillaPlus.Features.RecentlyLootedWindow;
 
 public unsafe class RecentlyLootedWindow : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Recently Looted Items Window",
-        Description = "Adds a window that shows a scrollable list of all items that you have looted this session.\n\n" +
-                      "Can only show items looted after this feature is enabled.",
+        DisplayName = Strings("ModificationDisplay_RecentlyLootedWindow"),
+        Description = Strings("ModificationDescription_RecentlyLootedWindow"),
         Type = ModificationType.NewWindow,
         Authors = ["MidoriKami"],
         ChangeLog = [
@@ -38,7 +37,7 @@ public unsafe class RecentlyLootedWindow : GameModification {
         addonRecentlyLooted = new NodeListAddon {
             Size = new Vector2(250.0f, 350.0f),
             InternalName = "RecentlyLooted",
-            Title = "Recently Looted Items",
+            Title = Strings("RecentlyLootedWindow_Title"),
             OpenCommand = "/recentloot",
             UpdateListFunction = UpdateList,
         };

--- a/VanillaPlus/Features/ResetInventoryTab/ResetInventoryTab.cs
+++ b/VanillaPlus/Features/ResetInventoryTab/ResetInventoryTab.cs
@@ -10,8 +10,8 @@ namespace VanillaPlus.Features.ResetInventoryTab;
 
 public unsafe class ResetInventoryTab : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Reset Inventory Tab",
-        Description = "Automatically resets the inventory to the first tab when opened.",
+        DisplayName = Strings("ModificationDisplay_ResetInventoryTab"),
+        Description = Strings("ModificationDescription_ResetInventoryTab"),
         Type = ModificationType.GameBehavior,
         Authors = ["Haselnussbomber"],
         ChangeLog = [

--- a/VanillaPlus/Features/ResourceBarPercentages/ResourceBarPercentages.cs
+++ b/VanillaPlus/Features/ResourceBarPercentages/ResourceBarPercentages.cs
@@ -12,8 +12,8 @@ namespace VanillaPlus.Features.ResourceBarPercentages;
 
 public unsafe class ResourceBarPercentages : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Show Resource Bars as Percentages",
-        Description = "Displays HP, MP, GP and CP bars as percentages instead of raw values.",
+        DisplayName = Strings("ModificationDisplay_ResourceBarPercentages"),
+        Description = Strings("ModificationDescription_ResourceBarPercentages"),
         Type = ModificationType.UserInterface,
         Authors = [ "Zeffuro" ],
         ChangeLog = [
@@ -38,37 +38,37 @@ public unsafe class ResourceBarPercentages : GameModification {
         configWindow = new ConfigAddon {
             Size = new Vector2(400.0f, 300.0f),
             InternalName = "ResourcePercentageConfig",
-            Title = "Resource Bar Percentages Config",
+            Title = Strings("ResourceBarPercentages_ConfigTitle"),
             Config = config,
         };
 
-        configWindow.AddCategory("Party List")
-            .AddCheckbox("Show on Party List", nameof(config.PartyListEnabled))
+        configWindow.AddCategory(Strings("ResourceBarPercentages_CategoryPartyList"))
+            .AddCheckbox(Strings("ResourceBarPercentages_ShowOnPartyList"), nameof(config.PartyListEnabled))
             .AddIndent()
-            .AddCheckbox("Apply to Player", nameof(config.PartyListSelf))
-            .AddCheckbox("Apply to Party Members", nameof(config.PartyListMembers))
-            .AddCheckbox("Change HP", nameof(config.PartyListHpEnabled))
-            .AddCheckbox("Change MP", nameof(config.PartyListMpEnabled))
-            .AddCheckbox("Change GP", nameof(config.PartyListGpEnabled))
-            .AddCheckbox("Change CP", nameof(config.PartyListCpEnabled));
+            .AddCheckbox(Strings("ResourceBarPercentages_ApplyToPlayer"), nameof(config.PartyListSelf))
+            .AddCheckbox(Strings("ResourceBarPercentages_ApplyToPartyMembers"), nameof(config.PartyListMembers))
+            .AddCheckbox(Strings("ResourceBarPercentages_ChangeHp"), nameof(config.PartyListHpEnabled))
+            .AddCheckbox(Strings("ResourceBarPercentages_ChangeMp"), nameof(config.PartyListMpEnabled))
+            .AddCheckbox(Strings("ResourceBarPercentages_ChangeGp"), nameof(config.PartyListGpEnabled))
+            .AddCheckbox(Strings("ResourceBarPercentages_ChangeCp"), nameof(config.PartyListCpEnabled));
 
-        configWindow.AddCategory("Parameter Widget")
-            .AddCheckbox("Show on Parameter Widget", nameof(config.ParameterWidgetEnabled))
+        configWindow.AddCategory(Strings("ResourceBarPercentages_CategoryParameterWidget"))
+            .AddCheckbox(Strings("ResourceBarPercentages_ShowOnParameterWidget"), nameof(config.ParameterWidgetEnabled))
             .AddIndent()
-            .AddCheckbox("Change HP", nameof(config.ParameterHpEnabled))
-            .AddCheckbox("Change MP", nameof(config.ParameterMpEnabled))
-            .AddCheckbox("Change GP", nameof(config.ParameterGpEnabled))
-            .AddCheckbox("Change CP", nameof(config.ParameterCpEnabled));
+            .AddCheckbox(Strings("ResourceBarPercentages_ChangeHp"), nameof(config.ParameterHpEnabled))
+            .AddCheckbox(Strings("ResourceBarPercentages_ChangeMp"), nameof(config.ParameterMpEnabled))
+            .AddCheckbox(Strings("ResourceBarPercentages_ChangeGp"), nameof(config.ParameterGpEnabled))
+            .AddCheckbox(Strings("ResourceBarPercentages_ChangeCp"), nameof(config.ParameterCpEnabled));
 
-        configWindow.AddCategory("Extra")
-            .AddCheckbox("Dead or Alive Mode", nameof(config.DeadOrAliveModeEnabled));
+        configWindow.AddCategory(Strings("ResourceBarPercentages_CategoryExtra"))
+            .AddCheckbox(Strings("ResourceBarPercentages_DeadOrAliveMode"), nameof(config.DeadOrAliveModeEnabled));
 
-        configWindow.AddCategory("Percentage Sign")
-            .AddCheckbox("Show Percentage Sign %", nameof(config.PercentageSignEnabled));
+        configWindow.AddCategory(Strings("ResourceBarPercentages_CategoryPercentageSign"))
+            .AddCheckbox(Strings("ResourceBarPercentages_ShowPercentageSign"), nameof(config.PercentageSignEnabled));
 
-        configWindow.AddCategory("Percentage Format")
-            .AddIntSlider("Decimal Places", 0, 2, nameof(config.DecimalPlaces))
-            .AddCheckbox("Show Decimals Only While Below 100%", nameof(config.ShowDecimalsBelowHundredOnly));
+        configWindow.AddCategory(Strings("ResourceBarPercentages_CategoryPercentageFormat"))
+            .AddIntSlider(Strings("ResourceBarPercentages_DecimalPlaces"), 0, 2, nameof(config.DecimalPlaces))
+            .AddCheckbox(Strings("ResourceBarPercentages_ShowDecimalsBelowHundred"), nameof(config.ShowDecimalsBelowHundredOnly));
         
         OpenConfigAction = configWindow.Toggle;
 
@@ -156,7 +156,7 @@ public unsafe class ResourceBarPercentages : GameModification {
 
         if (hudData.IsSelf() && config.PartyListSelf || !hudData.IsSelf() && !revertToDefault) {
             if (config.DeadOrAliveModeEnabled) {
-                hpGaugeTextNode->SetText(health.Current > 0 ? "Alive" : "Dead");
+                hpGaugeTextNode->SetText(health.Current > 0 ? Strings("ResourceBarPercentages_StatusAlive") : Strings("ResourceBarPercentages_StatusDead"));
             }
             else {
                 hpGaugeTextNode->SetText(GetCorrectText((uint)health.Current, (uint)health.Max, config.PartyListHpEnabled));

--- a/VanillaPlus/Features/RetainerSearchBar/RetainerSearchBar.cs
+++ b/VanillaPlus/Features/RetainerSearchBar/RetainerSearchBar.cs
@@ -4,8 +4,8 @@ namespace VanillaPlus.Features.RetainerSearchBar;
 
 public class RetainerSearchBar : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Retainer Search Bar",
-        Description = "Adds a search bar to the retainer window.",
+        DisplayName = Strings("ModificationDisplay_RetainerSearchBar"),
+        Description = Strings("ModificationDescription_RetainerSearchBar"),
         Type = ModificationType.UserInterface,
         SubType = ModificationSubType.Inventory,
         Authors = [ "MidoriKami" ],

--- a/VanillaPlus/Features/SaddlebagSearchBar/SaddlebagSearchBar.cs
+++ b/VanillaPlus/Features/SaddlebagSearchBar/SaddlebagSearchBar.cs
@@ -4,8 +4,8 @@ namespace VanillaPlus.Features.SaddlebagSearchBar;
 
 public class SaddlebagSearchBar : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Saddlebag Search Bar",
-        Description = "Adds a search bar to the saddlebag window.",
+        DisplayName = Strings("ModificationDisplay_SaddlebagSearchBar"),
+        Description = Strings("ModificationDescription_SaddlebagSearchBar"),
         Type = ModificationType.UserInterface,
         SubType = ModificationSubType.Inventory,
         Authors = [ "MidoriKami" ],

--- a/VanillaPlus/Features/SampleGameModification/SampleGameModification.cs
+++ b/VanillaPlus/Features/SampleGameModification/SampleGameModification.cs
@@ -5,8 +5,8 @@ namespace VanillaPlus.Features.SampleGameModification;
 // Template GameModification for more easily creating your own, can copy this entire folder and rename it.
 public class SampleGameModification : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "SampleDisplayName",
-        Description = "SampleDescription",
+        DisplayName = Strings("ModificationDisplay_SampleGameModification"),
+        Description = Strings("ModificationDescription_SampleGameModification"),
         Type = ModificationType.Hidden,
         Authors = [ "YourNameHere" ],
         ChangeLog = [

--- a/VanillaPlus/Features/SelectNextLootItem/SelectNextLootItem.cs
+++ b/VanillaPlus/Features/SelectNextLootItem/SelectNextLootItem.cs
@@ -9,9 +9,8 @@ namespace VanillaPlus.Features.SelectNextLootItem;
 
 public unsafe class SelectNextLootItem : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Automatically Select Next Loot Item",
-        Description = "Automatically advance to the next loot item after clicking Need, Greed, or Pass.\n\n" +
-                      "Note: this modification does not automatically roll on loot.",
+        DisplayName = Strings("ModificationDisplay_SelectNextLootItem"),
+        Description = Strings("ModificationDescription_SelectNextLootItem"),
         Type = ModificationType.GameBehavior,
         Authors = [ "MidoriKami" ],
         ChangeLog = [

--- a/VanillaPlus/Features/ShowAetherCurrents/ShowAetherCurrents.cs
+++ b/VanillaPlus/Features/ShowAetherCurrents/ShowAetherCurrents.cs
@@ -13,8 +13,8 @@ namespace VanillaPlus.Features.ShowAetherCurrents;
 
 public unsafe class ShowAetherCurrents : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Show Aether Currents",
-        Description = "Shows all available aether currents on the map.",
+        DisplayName = Strings("ModificationDisplay_ShowAetherCurrents"),
+        Description = Strings("ModificationDescription_ShowAetherCurrents"),
         Type = ModificationType.GameBehavior,
         Authors = [ "MidoriKami" ],
         ChangeLog = [
@@ -33,7 +33,7 @@ public unsafe class ShowAetherCurrents : GameModification {
         populateMapMarkersHook?.Enable();
 
         Services.Framework.RunOnFrameworkThread(() => {
-            tooltipString = Utf8String.FromString("Aether Current");
+            tooltipString = Utf8String.FromString(Strings("ShowAetherCurrents_Tooltip"));
             
             AgentMap.Instance()->ResetMapMarkers();
         });

--- a/VanillaPlus/Features/SkipTeleportConfirm/SkipTeleportConfirm.cs
+++ b/VanillaPlus/Features/SkipTeleportConfirm/SkipTeleportConfirm.cs
@@ -9,8 +9,8 @@ namespace VanillaPlus.Features.SkipTeleportConfirm;
 
 public unsafe class SkipTeleportConfirm : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Skip Teleport Confirm",
-        Description = "Skips the 'Teleport to [Location] for [amount] gil?' popup when using the map to teleport.",
+        DisplayName = Strings("ModificationDisplay_SkipTeleportConfirm"),
+        Description = Strings("ModificationDescription_SkipTeleportConfirm"),
         Type = ModificationType.GameBehavior,
         Authors = [ "MidoriKami" ],
         ChangeLog = [

--- a/VanillaPlus/Features/StickyShopCategories/StickyShopCategories.cs
+++ b/VanillaPlus/Features/StickyShopCategories/StickyShopCategories.cs
@@ -8,8 +8,8 @@ namespace VanillaPlus.Features.StickyShopCategories;
 
 public unsafe class StickyShopCategories : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Sticky Shop Categories",
-        Description = "Remembers the selected category and subcategories for certain vendors.",
+        DisplayName = Strings("ModificationDisplay_StickyShopCategories"),
+        Description = Strings("ModificationDescription_StickyShopCategories"),
         Type = ModificationType.GameBehavior,
         Authors = ["Era"],
         ChangeLog = [

--- a/VanillaPlus/Features/SuppressDialogAdvance/SuppressDialogAdvance.cs
+++ b/VanillaPlus/Features/SuppressDialogAdvance/SuppressDialogAdvance.cs
@@ -9,8 +9,8 @@ namespace VanillaPlus.Features.SuppressDialogAdvance;
 
 public unsafe class SuppressDialogueAdvance : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Suppress Dialogue Advance",
-        Description = "Prevents advancing a cutscene dialogue, unless you click on the dialogue box itself.",
+        DisplayName = Strings("ModificationDisplay_SuppressDialogAdvance"),
+        Description = Strings("ModificationDescription_SuppressDialogAdvance"),
         Type = ModificationType.GameBehavior,
         Authors = [ "MidoriKami" ],
         ChangeLog = [
@@ -27,12 +27,12 @@ public unsafe class SuppressDialogueAdvance : GameModification {
 
         configWindow = new ConfigAddon {
             InternalName = "SuppressDialogAdvanceConfig",
-            Title = "Suppress Dialog Advance Config",
+            Title = Strings("SuppressDialogAdvance_ConfigTitle"),
             Config = config,
         };
         
-        configWindow.AddCategory("General")
-            .AddCheckbox("Apply only in Cutscenes", nameof(config.ApplyOnlyInCutscenes));
+        configWindow.AddCategory(Strings("SuppressDialogAdvance_CategoryGeneral"))
+            .AddCheckbox(Strings("SuppressDialogAdvance_ApplyOnlyInCutscenes"), nameof(config.ApplyOnlyInCutscenes));
 
         OpenConfigAction = configWindow.Toggle;
         

--- a/VanillaPlus/Features/TargetCastBarCountdown/TargetCastBarCountdown.cs
+++ b/VanillaPlus/Features/TargetCastBarCountdown/TargetCastBarCountdown.cs
@@ -15,8 +15,8 @@ namespace VanillaPlus.Features.TargetCastBarCountdown;
 
 public unsafe class TargetCastBarCountdown : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Target Cast Bar Countdown",
-        Description = "Adds the time remaining for your targets current cast to the cast bar.",
+        DisplayName = Strings("ModificationDisplay_TargetCastBarCountdown"),
+        Description = Strings("ModificationDescription_TargetCastBarCountdown"),
         Authors = ["MidoriKami"],
         Type = ModificationType.UserInterface,
         ChangeLog = [
@@ -103,25 +103,25 @@ public unsafe class TargetCastBarCountdown : GameModification {
 
         configWindow = new ConfigAddon {
             InternalName = "TargetCastBarConfig",
-            Title = "Target Castbar Countdown Config",
+            Title = Strings("TargetCastBarCountdown_ConfigTitle"),
             Config = config,
         };
 
-        configWindow.AddCategory("Toggles")
-            .AddCheckbox("Show on Primary Target Castbar", nameof(config.PrimaryTarget))
-            .AddCheckbox("Show on Focus Target Castbar", nameof(config.FocusTarget))
-            .AddCheckbox("Show on Nameplate Target Castbar", nameof(config.NamePlateTargets));
+        configWindow.AddCategory(Strings("TargetCastBarCountdown_CategoryToggles"))
+            .AddCheckbox(Strings("TargetCastBarCountdown_CheckboxPrimary"), nameof(config.PrimaryTarget))
+            .AddCheckbox(Strings("TargetCastBarCountdown_CheckboxFocus"), nameof(config.FocusTarget))
+            .AddCheckbox(Strings("TargetCastBarCountdown_CheckboxNameplate"), nameof(config.NamePlateTargets));
 
-        configWindow.AddCategory("Target Castbar Style (Combined)")
+        configWindow.AddCategory(Strings("TargetCastBarCountdown_CategoryPrimaryStyle"))
             .AddNodeConfig(primaryTargetStyle);
 
-        configWindow.AddCategory("Target Castbar Style (Separate)")
+        configWindow.AddCategory(Strings("TargetCastBarCountdown_CategoryPrimaryAltStyle"))
             .AddNodeConfig(primaryTargetAltStyle);
         
-        configWindow.AddCategory("Focus Target Castbar Style")
+        configWindow.AddCategory(Strings("TargetCastBarCountdown_CategoryFocusStyle"))
             .AddNodeConfig(focusTargetStyle);
         
-        configWindow.AddCategory("Nameplate Castbar Style")
+        configWindow.AddCategory(Strings("TargetCastBarCountdown_CategoryNameplateStyle"))
             .AddNodeConfig(castBarEnemyStyle);
         
         OpenConfigAction = configWindow.Toggle;

--- a/VanillaPlus/Features/WindowBackground/WindowBackground.cs
+++ b/VanillaPlus/Features/WindowBackground/WindowBackground.cs
@@ -14,9 +14,8 @@ namespace VanillaPlus.Features.WindowBackground;
 
 public unsafe class WindowBackground : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Window Backgrounds",
-        Description = "Allows you to add a background to any native window.\n\n" +
-                      "Examples: Cast Bar, Target Health Bar, Inventory Widget, Todo List.",
+        DisplayName = Strings("ModificationDisplay_WindowBackground"),
+        Description = Strings("ModificationDescription_WindowBackground"),
         Authors = ["MidoriKami"],
         Type = ModificationType.UserInterface,
         ChangeLog = [
@@ -55,7 +54,7 @@ public unsafe class WindowBackground : GameModification {
 
         addonSearchAddon = new SearchAddon<StringInfoNode> {
             InternalName = "AddonSearch",
-            Title = "Window Search",
+            Title = Strings("WindowBackground_SearchTitle"),
             Size = new Vector2(350.0f, 600.0f),
             SortingOptions = [ "Visibility", "Alphabetical" ],
             SearchOptions = GetOptions(),
@@ -63,7 +62,7 @@ public unsafe class WindowBackground : GameModification {
 
         configWindow = new ListConfigAddon<WindowBackgroundSetting, WindowBackgroundConfigNode> {
             InternalName = "WindowBackgroundConfig",
-            Title = "Window Backgrounds Config",
+            Title = Strings("WindowBackground_ConfigTitle"),
             Size = new Vector2(600.0f, 500.0f),
             Options = config.Settings,
 

--- a/VanillaPlus/Features/WindowBackground/WindowBackgroundConfigNode.cs
+++ b/VanillaPlus/Features/WindowBackground/WindowBackgroundConfigNode.cs
@@ -23,10 +23,10 @@ public class WindowBackgroundConfigNode : ConfigNode<WindowBackgroundSetting> {
     
     public WindowBackgroundConfigNode() {
         CollisionNode.IsVisible = false;
-        
+
         colorPickerAddon = new ColorPickerAddon {
             InternalName = "WindowBackgroundColor",
-            Title = "Window Background Color Picker",
+            Title = Strings("WindowBackground_ColorPickerTitle"),
             DefaultColor = KnownColor.Black.Vector() with { W = 0.50f },
         };
         
@@ -43,7 +43,7 @@ public class WindowBackgroundConfigNode : ConfigNode<WindowBackgroundSetting> {
         verticalListNode.AttachNode(this);
 
         verticalListNode.AddNode(new CategoryTextNode {
-            String = "Background Color",
+            String = Strings("WindowBackground_CategoryBackgroundColor"),
         });
 
         var colorPreviewLayoutNode1 = new HorizontalListNode {
@@ -67,13 +67,13 @@ public class WindowBackgroundConfigNode : ConfigNode<WindowBackgroundSetting> {
             TextColor = ColorHelper.GetColor(8),
             TextOutlineColor = ColorHelper.GetColor(7),
             TextFlags = TextFlags.Edge | TextFlags.AutoAdjustNodeSize,
-            String = "Color",
+            String = Strings("WindowBackground_ColorLabel"),
             DrawFlags = DrawFlags.ClickableCursor,
         };
         colorPreviewLayoutNode1.AddNode(colorLabelNode1);
 
         verticalListNode.AddNode(0, new CategoryTextNode {
-            String = "Padding Size",
+            String = Strings("WindowBackground_CategoryPaddingSize"),
         });
 
         sizeEditWidget = new Vector2EditWidget {

--- a/VanillaPlus/Features/WondrousTailsProbabilities/WondrousTailsProbabilities.cs
+++ b/VanillaPlus/Features/WondrousTailsProbabilities/WondrousTailsProbabilities.cs
@@ -18,8 +18,8 @@ namespace VanillaPlus.Features.WondrousTailsProbabilities;
 
 public unsafe class WondrousTailsProbabilities : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Wondrous Tails Probabilities",
-        Description = "Displays current line probabilities and average reroll probabilities in the Wondrous Tails Book.",
+        DisplayName = Strings("ModificationDisplay_WondrousTailsProbabilities"),
+        Description = Strings("ModificationDescription_WondrousTailsProbabilities"),
         Authors = [ "MidoriKami" ],
         Type = ModificationType.UserInterface,
         ChangeLog = [

--- a/VanillaPlus/Features/WondrousTailsProbabilities/WondrousTailsSolver.cs
+++ b/VanillaPlus/Features/WondrousTailsProbabilities/WondrousTailsSolver.cs
@@ -158,24 +158,27 @@ public sealed unsafe partial class PerfectTails {
 
         // > 9 returns Error {-1,-1,-1} by the solver
         var values = Solve(GameState);
+        var lineChancesLabel = Strings("WondrousTailsProbabilities_LineChancesLabel");
+        var shuffleAverageLabel = Strings("WondrousTailsProbabilities_ShuffleAverageLabel");
 
         double[]? samples = null;
         if (stickersPlaced is > 0 and <= 7)
             samples = GetSample(stickersPlaced);
 
         if (values == Error) {
+            var errorPlaceholder = Strings("WondrousTailsProbabilities_ErrorPlaceholder");
             return new SeStringBuilder()
-                .AddText("Line Chances: ")
-                .AddUiForeground("error ", 704)
-                .AddUiForeground("error ", 704)
-                .AddUiForeground("error ", 704)
+                .AddText(lineChancesLabel)
+                .AddUiForeground(errorPlaceholder, 704)
+                .AddUiForeground(errorPlaceholder, 704)
+                .AddUiForeground(errorPlaceholder, 704)
                 .Build()
                 .EncodeWithNullTerminator();
         }
 
         var valuePayloads = StringFormatDoubles(values);
         var seString = new SeStringBuilder()
-            .AddText("Line Chances: ");
+            .AddText(lineChancesLabel);
 
         if (samples != null) {
             foreach (var (value, sample, valuePayload) in Enumerable.Range(0, values.Length).Select(i => (values[i], samples[i], valuePayloads[i]))) {
@@ -199,7 +202,8 @@ public sealed unsafe partial class PerfectTails {
                 seString.AddText("  ");
             }
 
-            seString.AddText("\rShuffle Average: ");
+            seString.AddText("\r");
+            seString.AddText(shuffleAverageLabel);
             seString.AddText(string.Join(" ", StringFormatDoubles(samples)));
         }
         else {

--- a/VanillaPlus/GlobalUsings.cs
+++ b/VanillaPlus/GlobalUsings.cs
@@ -1,2 +1,3 @@
 ﻿global using KamiToolKit.Extensions;
 global using VanillaPlus.Extensions;
+global using static VanillaPlus.Utilities.Localization;

--- a/VanillaPlus/InternalSystem/AddonChangelogBrowser.cs
+++ b/VanillaPlus/InternalSystem/AddonChangelogBrowser.cs
@@ -30,7 +30,7 @@ public class AddonChangelogBrowser : NativeAddon {
 
             foreach (var changelog in Modification.ModificationInfo.ChangeLog.OrderByDescending(log => log.Version)) {
                 var categoryNode = new TreeListCategoryNode {
-                    SeString = $"Version {changelog.Version}",
+                    SeString = Strings("VersionLabelFormat", changelog.Version),
                     Width = ContentSize.X,
                     OnToggle = _ => scrollingAreaNode.ContentHeight = categoryNodes.Sum(node => node.Height),
                 };

--- a/VanillaPlus/InternalSystem/AddonModificationBrowser.cs
+++ b/VanillaPlus/InternalSystem/AddonModificationBrowser.cs
@@ -35,7 +35,7 @@ public class AddonModificationBrowser : NativeAddon {
     
     private readonly AddonChangelogBrowser? changelogBrowser = new() {
         InternalName = "VPChangelog",
-        Title = "Vanilla Plus Changelog Browser",
+        Title = Strings("ChangelogBrowserTitle"),
         Size = new Vector2(450.0f, 400.0f),
     };
 
@@ -111,7 +111,7 @@ public class AddonModificationBrowser : NativeAddon {
         
         searchBoxNode = new TextInputNode {
             OnInputReceived = OnSearchBoxInputReceived,
-            PlaceholderString = "Search . . .",
+            PlaceholderString = Strings("SearchPlaceholder"),
             AutoSelectAll = true,
         };
         searchContainerNode.AddNode(searchBoxNode);
@@ -127,7 +127,7 @@ public class AddonModificationBrowser : NativeAddon {
             FontSize = 14,
             LineSpacing = 22,
             FontType = FontType.Axis,
-            String = "Please select an option on the left",
+            String = Strings("SelectionPrompt"),
             TextColor = ColorHelper.GetColor(1),
         };
         descriptionTextNode.AttachNode(descriptionContainerNode);
@@ -143,7 +143,7 @@ public class AddonModificationBrowser : NativeAddon {
         descriptionImageTextNode.AttachNode(descriptionContainerNode);
 
         changelogButtonNode = new TextButtonNode {
-            SeString = "Changelog",
+            SeString = Strings("ChangelogButtonLabel"),
             OnClick = OnChangelogButtonClicked,
             IsVisible = false,
         };
@@ -264,7 +264,9 @@ public class AddonModificationBrowser : NativeAddon {
 
         changelogButtonNode.IsVisible = true;
         descriptionVersionTextNode.IsVisible = true;
-        descriptionVersionTextNode.String = $"Version {selectedOption.Modification.Modification.ModificationInfo.Version}";
+        descriptionVersionTextNode.String = Strings(
+            "VersionLabelFormat",
+            selectedOption.Modification.Modification.ModificationInfo.Version);
     }
 
     private async void LoadModuleImage(string assetName) {
@@ -310,7 +312,7 @@ public class AddonModificationBrowser : NativeAddon {
         }
 
         descriptionTextNode.IsVisible = true;
-        descriptionTextNode.String = "Please select an option on the left";
+        descriptionTextNode.String = Strings("SelectionPrompt");
 
         descriptionImageFrame.Scale = Vector2.One;
         
@@ -327,7 +329,9 @@ public class AddonModificationBrowser : NativeAddon {
             }
 
             changelogBrowser.Modification = selectedOption.Modification.Modification;
-            changelogBrowser.Title = $"{selectedOption.ModificationInfo.DisplayName} Changelog";
+            changelogBrowser.Title = Strings(
+                "ChangelogTitleFormat",
+                selectedOption.ModificationInfo.DisplayName);
             changelogBrowser.Open();
         }
     }

--- a/VanillaPlus/InternalSystem/GameModificationOptionNode.cs
+++ b/VanillaPlus/InternalSystem/GameModificationOptionNode.cs
@@ -53,7 +53,7 @@ public class GameModificationOptionNode : SimpleComponentNode {
         erroringImageNode = new IconImageNode {
             IconId = 61502,
             FitTexture = true,
-            Tooltip = "Failed to load, this module has been disabled",
+            Tooltip = Strings("Tooltip_ModificationFailedToLoad"),
         };
         erroringImageNode.AttachNode(this);
 
@@ -67,7 +67,7 @@ public class GameModificationOptionNode : SimpleComponentNode {
         experimentalImageNode = new IconImageNode {
             IconId = 60073,
             FitTexture = true,
-            Tooltip = "Caution, this feature is experimental.\nMay contain bugs or crash your game.",
+            Tooltip = Strings("Tooltip_ExperimentalFeature"),
         };
         experimentalImageNode.AttachNode(this);
         
@@ -81,7 +81,7 @@ public class GameModificationOptionNode : SimpleComponentNode {
 
         reloadButtonNode = new CircleButtonNode {
             Icon = ButtonIcon.Refresh,
-            Tooltip = "Retry compatability check",
+            Tooltip = Strings("Tooltip_RetryCompatibility"),
             OnClick = () => {
                 System.ModificationManager.ReloadConflictedModules();
                 reloadButtonNode?.HideTooltip();
@@ -91,7 +91,7 @@ public class GameModificationOptionNode : SimpleComponentNode {
         
         configButtonNode = new CircleButtonNode {
             Icon = ButtonIcon.GearCog,
-            Tooltip = "Open configuration window",
+            Tooltip = Strings("Tooltip_OpenConfiguration"),
             OnClick = () => {
                 Modification?.Modification.OpenConfigAction?.Invoke();
                 OnClick?.Invoke();
@@ -123,7 +123,8 @@ public class GameModificationOptionNode : SimpleComponentNode {
         set {
             field = value;
             modificationNameNode.String = value.Modification.ModificationInfo.DisplayName;
-            authorNamesNode.String = $"By {string.Join(", ", value.Modification.ModificationInfo.Authors)}";
+            var authorList = string.Join(", ", value.Modification.ModificationInfo.Authors);
+            authorNamesNode.String = Strings("Label_ModAuthorBy", authorList);
 
             RefreshConfigWindowButton();
 

--- a/VanillaPlus/NativeElements/Addons/AddonConfigAddon.cs
+++ b/VanillaPlus/NativeElements/Addons/AddonConfigAddon.cs
@@ -34,7 +34,7 @@ public class AddonConfigAddon : NativeAddon {
 
         keybindAddon = new KeybindConfigAddon {
             InternalName = "KeybindConfig",
-            Title = "Keybind Config Window",
+            Title = Strings("AddonConfig_KeybindWindowTitle"),
             InitialKeybind = AddonConfig.Keybind,
             OnKeybindChanged = OnKeybindChanged,
         };
@@ -42,7 +42,7 @@ public class AddonConfigAddon : NativeAddon {
         keybindLabelNode = new CategoryTextNode {
             AlignmentType = AlignmentType.Left,
             Position = ContentStartPosition + new Vector2(0.0f, 10.0f),
-            String = "Keybind",
+            String = Strings("AddonConfig_KeybindLabel"),
         };
         keybindLabelNode.AttachNode(this);
 
@@ -69,7 +69,7 @@ public class AddonConfigAddon : NativeAddon {
         keybindEnableButtonNode = new TextButtonNode {
             Position = new Vector2(ContentStartPosition.X, keybindTextNode.Y + keybindTextNode.Height + 10.0f),
             Size = new Vector2(150.0f, 24.0f),
-            String = AddonConfig.KeybindEnabled ? "Disable" : "Enable",
+            String = AddonConfig.KeybindEnabled ? Strings("Common_Disable") : Strings("Common_Enable"),
             OnClick = OnKeybindToggleClicked,
         };
         keybindEnableButtonNode.AttachNode(this);
@@ -77,7 +77,7 @@ public class AddonConfigAddon : NativeAddon {
         editKeybindButtonNode = new TextButtonNode {
             Size = new Vector2(150.0f, 24.0f),
             Position = new Vector2(ContentStartPosition.X + ContentSize.X - 150.0f, keybindTextNode.Y + keybindTextNode.Height + 10.0f),
-            String = "Change Keybind",
+            String = Strings("AddonConfig_ChangeKeybind"),
             OnClick = keybindAddon.Toggle,
         };
         editKeybindButtonNode.AttachNode(this);
@@ -85,7 +85,7 @@ public class AddonConfigAddon : NativeAddon {
         inputComboLabelNode = new CategoryTextNode {
             AlignmentType = AlignmentType.Left,
             Position = new Vector2(ContentStartPosition.X - 2.0f, editKeybindButtonNode.Y + editKeybindButtonNode.Height + 15.0f),
-            String = "Window Size",
+            String = Strings("AddonConfig_WindowSizeLabel"),
         };
         inputComboLabelNode.AttachNode(this);
 
@@ -111,7 +111,7 @@ public class AddonConfigAddon : NativeAddon {
             TextColor = ColorHelper.GetColor(8),
             TextOutlineColor = ColorHelper.GetColor(7),
             TextFlags = TextFlags.Edge | TextFlags.AutoAdjustNodeSize,
-            String = "Width",
+            String = Strings("AddonConfig_WindowWidthLabel"),
         };
         windowWidthTextNode.AttachNode(windowSizeGridNode[0, 0]);
 
@@ -124,7 +124,7 @@ public class AddonConfigAddon : NativeAddon {
             TextColor = ColorHelper.GetColor(8),
             TextOutlineColor = ColorHelper.GetColor(7),
             TextFlags = TextFlags.Edge | TextFlags.AutoAdjustNodeSize,
-            String = "Height",
+            String = Strings("AddonConfig_WindowHeightLabel"),
         };
         windowHeightTextNode.AttachNode(windowSizeGridNode[1, 0]);
         
@@ -159,7 +159,7 @@ public class AddonConfigAddon : NativeAddon {
             TextColor = ColorHelper.GetColor(8),
             TextOutlineColor = ColorHelper.GetColor(7),
             TextFlags = TextFlags.Edge | TextFlags.AutoAdjustNodeSize,
-            String = "Changes won't take effect until the window is reopened",
+            String = Strings("AddonConfig_ReloadHint"),
         };
         editNoteTextNode.AttachNode(this);
     }
@@ -174,7 +174,7 @@ public class AddonConfigAddon : NativeAddon {
         if (keybindTextNode is null) return;
 
         AddonConfig.KeybindEnabled = !AddonConfig.KeybindEnabled;
-        keybindEnableButtonNode.String = AddonConfig.KeybindEnabled ? "Disable" : "Enable";
+        keybindEnableButtonNode.String = AddonConfig.KeybindEnabled ? Strings("Common_Disable") : Strings("Common_Enable");
         keybindTextNode.MultiplyColor = AddonConfig.KeybindEnabled ? new Vector3(1.0f, 1.0f, 1.0f) : new Vector3(0.5f, 0.5f, 0.5f);
         
         AddonConfig.Save();

--- a/VanillaPlus/NativeElements/Addons/KeybindConfigAddon.cs
+++ b/VanillaPlus/NativeElements/Addons/KeybindConfigAddon.cs
@@ -37,7 +37,7 @@ public unsafe class KeybindConfigAddon : NativeAddon {
         inputComboLabelNode = new CategoryTextNode {
             AlignmentType = AlignmentType.Left,
             Position = ContentStartPosition + new Vector2(0.0f, 10.0f),
-            String = "Input Desired Key Combo",
+            String = Strings("KeybindConfig_InputPrompt"),
         };
         inputComboLabelNode.AttachNode(this);
 
@@ -52,14 +52,14 @@ public unsafe class KeybindConfigAddon : NativeAddon {
             Size = new Vector2(ContentSize.X, 75.0f),
             FontSize = 24,
             AlignmentType = AlignmentType.Center,
-            String = "Press a Key Combo",
+            String = Strings("KeybindConfig_CurrentPrompt"),
         };
         currentComboTextNode.AttachNode(this);
 
         conflictsLabelNode = new CategoryTextNode {
             AlignmentType = AlignmentType.Left,
             Position = new Vector2(ContentStartPosition.X, currentComboTextNode.Position.Y + currentComboTextNode.Height),
-            String = "Keybind Conflict(s)",
+            String = Strings("KeybindConfig_ConflictsLabel"),
         };
         conflictsLabelNode.AttachNode(this);
 
@@ -78,7 +78,7 @@ public unsafe class KeybindConfigAddon : NativeAddon {
         conflictsScrollableAreaNode.AttachNode(this);
         
         conflictsScrollableAreaNode.ContentNode.AddNode(new CategoryTextNode {
-            String = "No Conflicts Detected",
+            String = Strings("KeybindConfig_NoConflicts"),
         });
         conflictsScrollableAreaNode.ContentHeight = conflictsScrollableAreaNode.ContentNode.Nodes.Sum(node => node.IsVisible ? node.Height : 0.0f);
 
@@ -91,7 +91,7 @@ public unsafe class KeybindConfigAddon : NativeAddon {
         confirmButtonNode = new TextButtonNode {
             Position = ContentStartPosition + new Vector2(0.0f, ContentSize.Y - 26.0f),
             Size = new Vector2(100.0f, 24.0f),
-            String = "Confirm",
+            String = Strings("Common_Confirm"),
             OnClick = () => {
                 var newKeybind = new Keybind {
                     Key = combo.FirstOrNull(key => key.IsKey) ?? VirtualKey.NO_KEY,
@@ -106,7 +106,7 @@ public unsafe class KeybindConfigAddon : NativeAddon {
         cancelButtonNode = new TextButtonNode {
             Position = ContentStartPosition + new Vector2(ContentSize.X - 100.0f, ContentSize.Y - 26.0f),
             Size = new Vector2(100.0f, 24.0f),
-            String = "Cancel",
+            String = Strings("Common_Cancel"),
             OnClick = Close,
         };
         cancelButtonNode.AttachNode(this);
@@ -142,7 +142,7 @@ public unsafe class KeybindConfigAddon : NativeAddon {
 
         if (conflicts.Count == 0) {
             conflictsScrollableAreaNode.ContentNode.AddNode(new CategoryTextNode {
-                String = "No Conflicts Detected",
+                String = Strings("KeybindConfig_NoConflicts"),
             });
         }
         else {

--- a/VanillaPlus/NativeElements/Addons/NodeListAddon.cs
+++ b/VanillaPlus/NativeElements/Addons/NodeListAddon.cs
@@ -32,7 +32,7 @@ public unsafe class NodeListAddon : NativeAddon {
 
         addonConfigWindow = new AddonConfigAddon {
             InternalName = $"{InternalName}Config",
-            Title = $"{InternalName} Configuration Window",
+            Title = Strings("NodeList_ConfigWindowTitle", InternalName),
             AddonConfig = config,
         };
     }
@@ -59,7 +59,7 @@ public unsafe class NodeListAddon : NativeAddon {
             if (field is null && value is not null) {
                 Services.CommandManager.AddHandler(value, new CommandInfo(OnOpenCommand) {
                     DisplayOrder = 3,
-                    HelpMessage = $"Opens the {Title} Window",
+                    HelpMessage = Strings("NodeList_OpenCommandHelp", (Title.ToString() ?? InternalName)),
                 });
                 
                 field = value;

--- a/VanillaPlus/NativeElements/Addons/RenameAddon.cs
+++ b/VanillaPlus/NativeElements/Addons/RenameAddon.cs
@@ -36,7 +36,7 @@ public class RenameAddon : NativeAddon {
         confirmButton = new TextButtonNode {
             Position = new Vector2(ContentStartPosition.X, targetYPos),
             Size = buttonSize,
-            String = "Confirm",
+            String = Strings("Common_Confirm"),
             OnClick = () => {
                 OnRenameComplete?.Invoke(inputNode.String);
                 Close();
@@ -47,7 +47,7 @@ public class RenameAddon : NativeAddon {
         cancelButton = new TextButtonNode {
             Position = new Vector2(ContentSize.X - buttonSize.X + ContentPadding.X, targetYPos),
             Size = buttonSize,
-            String = "Cancel",
+            String = Strings("Common_Cancel"),
             OnClick = Close,
         };
         cancelButton.AttachNode(this);

--- a/VanillaPlus/NativeElements/Addons/SearchAddons/GearsetSearchAddon.cs
+++ b/VanillaPlus/NativeElements/Addons/SearchAddons/GearsetSearchAddon.cs
@@ -11,9 +11,9 @@ public static unsafe class GearsetSearchAddon {
     public static SearchAddon<GearsetInfo> GetAddon() => new() {
         Size = new Vector2(275.0f, 600.0f),
         InternalName = "GearsetSearch",
-        Title = "Gearset Search",
+        Title = Strings("SearchAddon_GearsetTitle"),
         SearchOptions = [],
-        SortingOptions = [ "Alphabetical", "Id" ],
+        SortingOptions = [ Strings("SortOption_Alphabetical"), Strings("SortOption_Id") ],
     };
 
     public static void UpdateGearsets(this SearchAddon<GearsetInfo> addon, List<int>? omissionIds = null)

--- a/VanillaPlus/NativeElements/Addons/SearchAddons/TerritorySearchAddon.cs
+++ b/VanillaPlus/NativeElements/Addons/SearchAddons/TerritorySearchAddon.cs
@@ -10,7 +10,7 @@ public static class TerritorySearchAddon {
     public static LuminaSearchAddon<TerritoryType> GetAddon() => new () {
         Size = new Vector2(350.0f, 600.0f),
         InternalName = "TerritorySearch",
-        Title = "Zone Search",
+        Title = Strings("SearchAddon_TerritoryTitle"),
         SearchOptions = Services.DataManager.GetExcelSheet<TerritoryType>()
             .Where(territory => territory.LoadingImage.RowId is not 0)
             .Where(territory => !territory.PlaceName.Value.Name.ToString().IsNullOrEmpty())

--- a/VanillaPlus/NativeElements/Addons/SearchableNodeListAddon.cs
+++ b/VanillaPlus/NativeElements/Addons/SearchableNodeListAddon.cs
@@ -59,11 +59,11 @@ public unsafe class SearchableNodeListAddon : NodeListAddon {
                 reverseSort = !reverseSort;
                 OnFilterUpdated(filterOption, reverseSort);
             },
-            Tooltip = "Reverse Sort Direction",
+            Tooltip = Strings("Tooltip_ReverseSortDirection"),
         };
 
         textInputNode = new TextInputNode {
-            PlaceholderString = "Search . . .",
+            PlaceholderString = Strings("SearchPlaceholder"),
         };
         textInputNode.SeString = searchText;
 

--- a/VanillaPlus/NativeElements/Config/ConfigEntries/ColorConfig.cs
+++ b/VanillaPlus/NativeElements/Config/ConfigEntries/ColorConfig.cs
@@ -14,7 +14,7 @@ public class ColorConfig : BaseConfigEntry {
 
     private readonly ColorPickerAddon colorPickerInstance = new() {
         InternalName = "ColorPicker",
-        Title = "Color Picker Window",
+        Title = Strings("ColorPicker_WindowTitle"),
     };
 
     public override NodeBase BuildNode() {

--- a/VanillaPlus/NativeElements/Config/NodeEntries/NodeConfig.cs
+++ b/VanillaPlus/NativeElements/Config/NodeEntries/NodeConfig.cs
@@ -34,7 +34,7 @@ public class NodeConfig<T> : IConfigEntry where T : NodeStyle, new() {
         };
 
         var labelNode = new LabelTextNode {
-            String = "Position",
+            String = Strings("NodeStyle_PositionLabel"),
             Size = new Vector2(ElementStartOffset, 28.0f),
         };
         container.AddNode(labelNode);

--- a/VanillaPlus/NativeElements/Config/NodeEntries/TextNodeConfig.cs
+++ b/VanillaPlus/NativeElements/Config/NodeEntries/TextNodeConfig.cs
@@ -18,7 +18,7 @@ public class TextNodeConfig : NodeConfig<TextNodeStyle> {
 
         colorPickerAddon = new ColorPickerAddon {
             InternalName = "ColorPicker",
-            Title = "Color Picker",
+            Title = Strings("ColorPicker_WindowTitle"),
         };
     }
 
@@ -45,7 +45,7 @@ public class TextNodeConfig : NodeConfig<TextNodeStyle> {
         };
 
         var labelNode = new LabelTextNode {
-            String = "Text Color",
+            String = Strings("TextNodeConfig_TextColor"),
             Size = new Vector2(100.0f, 28.0f),
         };
         labelNode.AttachNode(container);
@@ -86,7 +86,7 @@ public class TextNodeConfig : NodeConfig<TextNodeStyle> {
         };
 
         var labelNode = new LabelTextNode {
-            String = "Text Outline",
+            String = Strings("TextNodeConfig_TextOutline"),
             Size = new Vector2(100.0f, 28.0f),
         };
         labelNode.AttachNode(container);
@@ -128,7 +128,7 @@ public class TextNodeConfig : NodeConfig<TextNodeStyle> {
         };
 
         var labelNode = new LabelTextNode {
-            String = "Font Size",
+            String = Strings("TextNodeConfig_FontSize"),
             Size = new Vector2(100.0f, 28.0f),
         };
         container.AddNode(labelNode);
@@ -154,7 +154,7 @@ public class TextNodeConfig : NodeConfig<TextNodeStyle> {
         };
         
         var labelNode = new LabelTextNode {
-            String = "Font",
+            String = Strings("TextNodeConfig_Font"),
             Size = new Vector2(100.0f, 28.0f),
         };
         container.AddNode(labelNode);
@@ -182,7 +182,7 @@ public class TextNodeConfig : NodeConfig<TextNodeStyle> {
         };
         
         var labelNode = new LabelTextNode {
-            String = "Alignment",
+            String = Strings("TextNodeConfig_Alignment"),
             Size = new Vector2(100.0f, 28.0f),
         };
         container.AddNode(labelNode);

--- a/VanillaPlus/NativeElements/Nodes/IconWithCountNode.cs
+++ b/VanillaPlus/NativeElements/Nodes/IconWithCountNode.cs
@@ -43,8 +43,8 @@ public class IconWithCountNode : ResNode {
         set {
             if (ShowCountWhenOne || value > 1) {
                 countTextNode.String = value switch {
-                    >= 1_000_000 => $"{value / 1_000_000}m",
-                    >= 10_000 => $"{value / 1_000}k",
+                    >= 1_000_000 => Strings("IconWithCount_MillionsFormat", value / 1_000_000),
+                    >= 10_000 => Strings("IconWithCount_ThousandsFormat", value / 1_000),
                     _ => $"{value}",
                 };
             }

--- a/VanillaPlus/NativeElements/Nodes/TextInputWithHintNode.cs
+++ b/VanillaPlus/NativeElements/Nodes/TextInputWithHintNode.cs
@@ -12,7 +12,7 @@ public class TextInputWithHintNode : SimpleComponentNode {
 
     public TextInputWithHintNode() {
         textInputNode = new TextInputNode {
-            PlaceholderString = "Search . . .",
+            PlaceholderString = Strings("SearchPlaceholder"),
         };
         textInputNode.AttachNode(this);
 
@@ -20,11 +20,7 @@ public class TextInputWithHintNode : SimpleComponentNode {
             TexturePath = "ui/uld/CircleButtons.tex",
             TextureCoordinates = new Vector2(112.0f, 84.0f),
             TextureSize = new Vector2(28.0f, 28.0f),
-            Tooltip = new SeStringBuilder()
-                .Append("[VanillaPlus]: Supports Regex Search")
-                .AppendNewLine()
-                .Append("Start input with '$' to search by description")
-                .ToReadOnlySeString(),
+            Tooltip = Strings("Tooltip_SearchRegexSupport"),
         };
         helpNode.AttachNode(this);
     }

--- a/VanillaPlus/Resources/Strings.ja.resx
+++ b/VanillaPlus/Resources/Strings.ja.resx
@@ -1,0 +1,1124 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+	<xsd:schema id="root" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+		<xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+		<xsd:element name="root" msdata:IsDataSet="true">
+			<xsd:complexType>
+				<xsd:choice maxOccurs="unbounded">
+					<xsd:element name="metadata">
+						<xsd:complexType>
+							<xsd:sequence>
+								<xsd:element name="value" type="xsd:string" minOccurs="0" />
+							</xsd:sequence>
+							<xsd:attribute name="name" use="required" type="xsd:string" />
+							<xsd:attribute name="type" type="xsd:string" />
+							<xsd:attribute name="mimetype" type="xsd:string" />
+							<xsd:attribute ref="xml:space" />
+						</xsd:complexType>
+					</xsd:element>
+					<xsd:element name="assembly">
+						<xsd:complexType>
+							<xsd:attribute name="alias" type="xsd:string" />
+							<xsd:attribute name="name" type="xsd:string" />
+						</xsd:complexType>
+					</xsd:element>
+					<xsd:element name="data">
+						<xsd:complexType>
+							<xsd:sequence>
+								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+								<xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+							</xsd:sequence>
+							<xsd:attribute name="name" type="xsd:string" use="required" />
+							<xsd:attribute name="type" type="xsd:string" />
+							<xsd:attribute name="mimetype" type="xsd:string" />
+							<xsd:attribute ref="xml:space" />
+						</xsd:complexType>
+					</xsd:element>
+					<xsd:element name="resheader">
+						<xsd:complexType>
+							<xsd:sequence>
+								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+							</xsd:sequence>
+							<xsd:attribute name="name" type="xsd:string" use="required" />
+						</xsd:complexType>
+					</xsd:element>
+				</xsd:choice>
+			</xsd:complexType>
+		</xsd:element>
+	</xsd:schema>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>2.0</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<data name="Button_SavePreset" xml:space="preserve">
+		<value>プリセットを保存</value>
+	</data>
+	<data name="ChangelogBrowserTitle" xml:space="preserve">
+		<value>Vanilla Plus 更新履歴ビューアー</value>
+	</data>
+	<data name="ChangelogButtonLabel" xml:space="preserve">
+		<value>更新履歴</value>
+	</data>
+	<data name="ChangelogTitleFormat" xml:space="preserve">
+		<value>{0} の更新履歴</value>
+	</data>
+	<data name="CommandHelpOpenBrowser" xml:space="preserve">
+		<value>改造ブラウザーを開く</value>
+	</data>
+	<data name="ConfigCategory_Animations" xml:space="preserve">
+		<value>アニメーション</value>
+	</data>
+	<data name="ConfigCategory_Colors" xml:space="preserve">
+		<value>カラー</value>
+	</data>
+	<data name="ConfigCategory_Icon" xml:space="preserve">
+		<value>アイコン</value>
+	</data>
+	<data name="ConfigLabel_ButtonColor" xml:space="preserve">
+		<value>ボタン</value>
+	</data>
+	<data name="ConfigLabel_EnableAnimations" xml:space="preserve">
+		<value>アニメーションを有効にする</value>
+	</data>
+	<data name="ConfigLabel_Icon" xml:space="preserve">
+		<value>アイコン</value>
+	</data>
+	<data name="ConfigLabel_LaneColor" xml:space="preserve">
+		<value>レーン</value>
+	</data>
+	<data name="BetterCursor_CategoryFunctions" xml:space="preserve">
+		<value>機能</value>
+	</data>
+	<data name="BetterCursor_CategoryIconSelection" xml:space="preserve">
+		<value>アイコン選択</value>
+	</data>
+	<data name="BetterCursor_CategoryStyle" xml:space="preserve">
+		<value>スタイル</value>
+	</data>
+	<data name="BetterCursor_CategoryVisibility" xml:space="preserve">
+		<value>可視性</value>
+	</data>
+	<data name="BetterCursor_ConfigTitle" xml:space="preserve">
+		<value>Better Cursor 設定</value>
+	</data>
+	<data name="BetterCursor_EnableAnimation" xml:space="preserve">
+		<value>アニメーションを有効化</value>
+	</data>
+	<data name="BetterCursor_HideOnCameraMove" xml:space="preserve">
+		<value>左/右ボタン長押し中は非表示</value>
+	</data>
+	<data name="BetterCursor_LabelColor" xml:space="preserve">
+		<value>カラー</value>
+	</data>
+	<data name="BetterCursor_LabelIcon" xml:space="preserve">
+		<value>アイコン</value>
+	</data>
+	<data name="BetterCursor_LabelSize" xml:space="preserve">
+		<value>サイズ</value>
+	</data>
+	<data name="BetterCursor_OnlyShowInCombat" xml:space="preserve">
+		<value>戦闘中のみ表示</value>
+	</data>
+	<data name="BetterCursor_OnlyShowInDuties" xml:space="preserve">
+		<value>コンテンツ中のみ表示</value>
+	</data>
+	<data name="CurrencyOverlay_ConfigTitle" xml:space="preserve">
+		<value>通貨オーバーレイ設定</value>
+	</data>
+	<data name="CurrencyOverlay_ItemSearchTitle" xml:space="preserve">
+		<value>アイテム検索</value>
+	</data>
+	<data name="CurrencyOverlay_SortOptionAlphabetical" xml:space="preserve">
+		<value>五十音順</value>
+	</data>
+	<data name="CurrencyOverlay_SortOptionId" xml:space="preserve">
+		<value>ID順</value>
+	</data>
+	<data name="WindowBackground_ConfigTitle" xml:space="preserve">
+		<value>ウィンドウ背景設定</value>
+	</data>
+	<data name="WindowBackground_SearchTitle" xml:space="preserve">
+		<value>ウィンドウ検索</value>
+	</data>
+	<data name="WindowBackground_SortOptionAlphabetical" xml:space="preserve">
+		<value>五十音順</value>
+	</data>
+	<data name="WindowBackground_SortOptionVisibility" xml:space="preserve">
+		<value>表示状態</value>
+	</data>
+	<data name="WindowBackground_ColorPickerTitle" xml:space="preserve">
+		<value>ウィンドウ背景カラーピッカー</value>
+	</data>
+	<data name="WindowBackground_CategoryBackgroundColor" xml:space="preserve">
+		<value>背景色</value>
+	</data>
+	<data name="WindowBackground_ColorLabel" xml:space="preserve">
+		<value>カラー</value>
+	</data>
+	<data name="WindowBackground_CategoryPaddingSize" xml:space="preserve">
+		<value>パディングサイズ</value>
+	</data>
+	<data name="TargetCastBarCountdown_CategoryFocusStyle" xml:space="preserve">
+		<value>フォーカスターゲット詠唱バーのスタイル</value>
+	</data>
+	<data name="TargetCastBarCountdown_CategoryNameplateStyle" xml:space="preserve">
+		<value>ネームプレート詠唱バーのスタイル</value>
+	</data>
+	<data name="TargetCastBarCountdown_CategoryPrimaryAltStyle" xml:space="preserve">
+		<value>ターゲット詠唱バーのスタイル（分離）</value>
+	</data>
+	<data name="TargetCastBarCountdown_CategoryPrimaryStyle" xml:space="preserve">
+		<value>ターゲット詠唱バーのスタイル（統合）</value>
+	</data>
+	<data name="TargetCastBarCountdown_CategoryToggles" xml:space="preserve">
+		<value>切り替え</value>
+	</data>
+	<data name="TargetCastBarCountdown_CheckboxFocus" xml:space="preserve">
+		<value>フォーカスターゲット詠唱バーに表示</value>
+	</data>
+	<data name="TargetCastBarCountdown_CheckboxNameplate" xml:space="preserve">
+		<value>ネームプレート詠唱バーに表示</value>
+	</data>
+	<data name="TargetCastBarCountdown_CheckboxPrimary" xml:space="preserve">
+		<value>メインターゲット詠唱バーに表示</value>
+	</data>
+	<data name="TargetCastBarCountdown_ConfigTitle" xml:space="preserve">
+		<value>ターゲット詠唱バー残り時間設定</value>
+	</data>
+	<data name="SuppressDialogAdvance_ApplyOnlyInCutscenes" xml:space="preserve">
+		<value>カットシーン中のみ適用</value>
+	</data>
+	<data name="SuppressDialogAdvance_CategoryGeneral" xml:space="preserve">
+		<value>一般</value>
+	</data>
+	<data name="SuppressDialogAdvance_ConfigTitle" xml:space="preserve">
+		<value>ダイアログ自動送り抑制設定</value>
+	</data>
+	<data name="ClearSelectedDuties_ConfigTitle" xml:space="preserve">
+		<value>選択済みコンテンツ解除設定</value>
+	</data>
+	<data name="ClearSelectedDuties_DisableWhenUnrestricted" xml:space="preserve">
+		<value>制限解除時は無効</value>
+	</data>
+	<data name="ClearSelectedDuties_SettingsCategory" xml:space="preserve">
+		<value>設定</value>
+	</data>
+	<data name="Label_ModAuthorBy" xml:space="preserve">
+		<value>作者: {0}</value>
+	</data>
+	<data name="ModificationBrowserTitle" xml:space="preserve">
+		<value>Vanilla Plus 改造ブラウザー</value>
+	</data>
+	<data name="ModificationDescription_MiniCactpotHelper" xml:space="preserve">
+		<value>ミニ・くじテンダーで次に開くべきマスを表示します。</value>
+	</data>
+	<data name="ModificationDescription_PartyFinderPresets" xml:space="preserve">
+		<value>コンテンツファインダー募集ウィンドウの設定をプリセットとして保存・呼び出せます。</value>
+	</data>
+	<data name="ModificationDisplay_MiniCactpotHelper" xml:space="preserve">
+		<value>ミニ・くじテンダー支援</value>
+	</data>
+	<data name="ModificationDisplay_PartyFinderPresets" xml:space="preserve">
+		<value>募集プリセット</value>
+	</data>
+	<data name="Preset_DefaultOption" xml:space="preserve">
+		<value>保存済みプリセットなし</value>
+	</data>
+	<data name="Preset_DontUseOption" xml:space="preserve">
+		<value>プリセットを使用しない</value>
+	</data>
+	<data name="SearchPlaceholder" xml:space="preserve">
+		<value>検索...</value>
+	</data>
+	<data name="SelectionPrompt" xml:space="preserve">
+		<value>左側からオプションを選択してください</value>
+	</data>
+	<data name="Title_MiniCactpotConfig" xml:space="preserve">
+		<value>ミニ・くじテンダー支援設定</value>
+	</data>
+	<data name="Title_PartyFinderPreset" xml:space="preserve">
+		<value>募集プリセット</value>
+	</data>
+	<data name="Title_PresetConfigManager" xml:space="preserve">
+		<value>プリセット管理</value>
+	</data>
+	<data name="Tooltip_ConfigEzMiniCactpot" xml:space="preserve">
+		<value>EzMiniCactpot プラグインを設定</value>
+	</data>
+	<data name="Tooltip_ExperimentalFeature" xml:space="preserve">
+		<value>注意: この機能は実験中です。
+不具合やクラッシュの恐れがあります。</value>
+	</data>
+	<data name="Tooltip_ModificationFailedToLoad" xml:space="preserve">
+		<value>読み込みに失敗しました。このモジュールは無効化されています。</value>
+	</data>
+	<data name="Tooltip_NoPresets" xml:space="preserve">
+		<value>[VanillaPlus]: プリセットがありません</value>
+	</data>
+	<data name="Tooltip_OpenConfiguration" xml:space="preserve">
+		<value>設定ウィンドウを開く</value>
+	</data>
+	<data name="Tooltip_ReverseSortDirection" xml:space="preserve">
+		<value>並び順を逆にする</value>
+	</data>
+	<data name="Tooltip_RetryCompatibility" xml:space="preserve">
+		<value>互換性チェックを再試行</value>
+	</data>
+	<data name="Tooltip_SavePreset" xml:space="preserve">
+		<value>[VanillaPlus]: 現在の設定をプリセットに保存</value>
+	</data>
+	<data name="Tooltip_SearchRegexSupport" xml:space="preserve">
+		<value>[VanillaPlus]: 正規表現検索に対応
+説明で検索する場合は入力を &apos;$&apos; で始めてください</value>
+	</data>
+	<data name="Tooltip_SelectPreset" xml:space="preserve">
+		<value>[VanillaPlus]: プリセットを選択</value>
+	</data>
+	<data name="DutyTimer_CompletedMessage" xml:space="preserve">
+		<value>コンテンツ完了時間: {0}</value>
+	</data>
+	<data name="DutyLoot_Context_AddFavorite" xml:space="preserve">
+		<value>お気に入りに追加</value>
+	</data>
+	<data name="DutyLoot_Context_Link" xml:space="preserve">
+		<value>リンク</value>
+	</data>
+	<data name="DutyLoot_Context_RemoveFavorite" xml:space="preserve">
+		<value>お気に入りから削除</value>
+	</data>
+	<data name="DutyLoot_Context_SearchItem" xml:space="preserve">
+		<value>アイテムを検索</value>
+	</data>
+	<data name="DutyLoot_Context_SearchRecipes" xml:space="preserve">
+		<value>この素材を使うレシピを検索</value>
+	</data>
+	<data name="DutyLoot_Context_TryOn" xml:space="preserve">
+		<value>試着する</value>
+	</data>
+	<data name="DutyLoot_Filter_All" xml:space="preserve">
+		<value>全アイテム</value>
+	</data>
+	<data name="DutyLoot_Filter_Equipment" xml:space="preserve">
+		<value>装備品</value>
+	</data>
+	<data name="DutyLoot_Filter_Favorites" xml:space="preserve">
+		<value>お気に入り</value>
+	</data>
+	<data name="DutyLoot_Filter_Misc" xml:space="preserve">
+		<value>その他</value>
+	</data>
+	<data name="DutyLoot_LoadingMessage" xml:space="preserve">
+		<value>戦利品データを読み込み中...</value>
+	</data>
+	<data name="DutyLoot_NoItemsMessage" xml:space="preserve">
+		<value>このコンテンツの戦利品データは見つかりませんでした。
+
+データは外部提供のため不完全な場合があります。</value>
+	</data>
+	<data name="DutyLoot_NoResultsMessage" xml:space="preserve">
+		<value>該当なし</value>
+	</data>
+	<data name="DutyLoot_Tooltip_InDutyButton" xml:space="preserve">
+		<value>[VanillaPlus] コンテンツ戦利品プレビューを開く</value>
+	</data>
+	<data name="DutyLoot_Tooltip_JournalButton" xml:space="preserve">
+		<value>このコンテンツで入手できる戦利品を表示します。</value>
+	</data>
+	<data name="FateEntry_LevelRangeFormat" xml:space="preserve">
+		<value>Lv.{0}-{1}</value>
+	</data>
+	<data name="FateEntry_LevelUnknown" xml:space="preserve">
+		<value>Lv.???</value>
+	</data>
+	<data name="FateListWindow_Title" xml:space="preserve">
+		<value>FATEリスト</value>
+	</data>
+	<data name="HUDPresets_ButtonDelete" xml:space="preserve">
+		<value>削除</value>
+	</data>
+	<data name="HUDPresets_ButtonLoad" xml:space="preserve">
+		<value>読み込む</value>
+	</data>
+	<data name="HUDPresets_ButtonLoadTooltip" xml:space="preserve">
+		<value>選択したプリセットを読み込む</value>
+	</data>
+	<data name="HUDPresets_ButtonOverwrite" xml:space="preserve">
+		<value>上書き</value>
+	</data>
+	<data name="HUDPresets_ButtonOverwriteTooltip" xml:space="preserve">
+		<value>選択したプリセットを上書きする</value>
+	</data>
+	<data name="HUDPresets_ButtonSave" xml:space="preserve">
+		<value>保存</value>
+	</data>
+	<data name="HUDPresets_DefaultOption" xml:space="preserve">
+		<value>未選択</value>
+	</data>
+	<data name="HUDPresets_DeleteTooltip" xml:space="preserve">
+		<value>開発中
+プリセットファイルは手動で削除してください</value>
+	</data>
+	<data name="HUDPresets_DropdownTooltip" xml:space="preserve">
+		<value>HUDレイアウトプリセットを選択</value>
+	</data>
+	<data name="HUDPresets_Label" xml:space="preserve">
+		<value>[VanillaPlus] HUDプリセット</value>
+	</data>
+	<data name="HUDPresets_PlaceholderNewPreset" xml:space="preserve">
+		<value>新しいプリセット名</value>
+	</data>
+	<data name="HUDPresets_RenameTitle" xml:space="preserve">
+		<value>HUDプリセット名</value>
+	</data>
+	<data name="HUDPresets_SaveTooltipDisabled" xml:space="preserve">
+		<value>新規保存の前に上部の保存を押してください</value>
+	</data>
+	<data name="HUDPresets_SaveTooltipEnabled" xml:space="preserve">
+		<value>現在のUIを新しいプリセットとして保存</value>
+	</data>
+	<data name="Label_LocationDisplayInstructions" xml:space="preserve">
+		<value>以下のテキストボックスで表示形式を指定してください。
+文字列内に {0} {1} {2} {3} {4} を配置するとそれぞれの値が挿入されます。
+
+{0} - リージョン（例: ノーザン・エンプティ）
+{1} - エリア（例: オールド・シャーレアン）
+{2} - ロケーション（例: アルカソン・デザイン）
+{3} - サブロケーション（例: オールド・シャーレアン・エーテライトプラザ）
+{4} - ハウジングエリア（例: 第14区）</value>
+	</data>
+	<data name="LocationDisplay_DefaultEntryFormat" xml:space="preserve">
+		<value>{0}, {1}, {2}, {3}</value>
+	</data>
+	<data name="LocationDisplay_DefaultTooltipFormat" xml:space="preserve">
+		<value>{0}, {1}, {2}, {3}</value>
+	</data>
+	<data name="LocationDisplay_InfoBarEntryLabel" xml:space="preserve">
+		<value>情報バー項目</value>
+	</data>
+	<data name="LocationDisplay_InfoBarTooltipLabel" xml:space="preserve">
+		<value>情報バーのツールチップ</value>
+	</data>
+	<data name="LocationDisplay_ResetButton" xml:space="preserve">
+		<value>初期設定に戻す</value>
+	</data>
+	<data name="LocationDisplay_ShowInstanceNumber" xml:space="preserve">
+		<value>インスタンス番号を表示</value>
+	</data>
+	<data name="LocationDisplay_ShowPreciseHousing" xml:space="preserve">
+		<value>ハウジングの詳細位置を表示</value>
+	</data>
+	<data name="LocationDisplay_ConfigTitle" xml:space="preserve">
+		<value>ロケーション表示設定</value>
+	</data>
+	<data name="LocationDisplay_DtrEntryName" xml:space="preserve">
+		<value>VanillaPlus - LocationDisplay</value>
+	</data>
+	<data name="LocationDisplay_WardFormat" xml:space="preserve">
+		<value>{0}区</value>
+	</data>
+	<data name="LocationDisplay_SubdivisionLabel" xml:space="preserve">
+		<value>サブディビジョン</value>
+	</data>
+	<data name="LocationDisplay_ApartmentFormat" xml:space="preserve">
+		<value>アパート {0}</value>
+	</data>
+	<data name="LocationDisplay_ApartmentLobby" xml:space="preserve">
+		<value>ロビー</value>
+	</data>
+	<data name="LocationDisplay_PlotFormat" xml:space="preserve">
+		<value>{0}番地</value>
+	</data>
+	<data name="LocationDisplay_RoomFormat" xml:space="preserve">
+		<value>{0}号室</value>
+	</data>
+	<data name="MissingJobStone_Tooltip" xml:space="preserve">
+		<value>[VanillaPlus]: クリックでロックを解除</value>
+	</data>
+	<data name="MissingJobStone_TooltipWithCountdown" xml:space="preserve">
+		<value>[VanillaPlus]: クリックでロックを解除
+残り {0} 回</value>
+	</data>
+	<data name="MissingJobStone_WarningText" xml:space="preserve">
+		<value>アーティファクト装備がありません！</value>
+	</data>
+	<data name="ModificationDescription_ArmourySearchBar" xml:space="preserve">
+		<value>アーマリーチェストに検索欄を追加します。</value>
+	</data>
+	<data name="ModificationDescription_ClearFlag" xml:space="preserve">
+		<value>ミニマップを右クリックして現在の旗を削除できます。</value>
+	</data>
+	<data name="ModificationDescription_ClearSelectedDuties" xml:space="preserve">
+		<value>コンテンツファインダーを開いた際に選択済みのコンテンツを解除します。</value>
+	</data>
+	<data name="ModificationDescription_ClearTextInputs" xml:space="preserve">
+		<value>テキスト入力欄を右クリックでクリアできます。</value>
+	</data>
+	<data name="ModificationDescription_WondrousTailsProbabilities" xml:space="preserve">
+		<value>ワンダラーテイルズ手帳に現在のライン確率と平均リロール確率を表示します。</value>
+	</data>
+	<data name="ModificationDescription_WindowBackground" xml:space="preserve">
+		<value>任意のネイティブウィンドウに背景を追加できます。
+
+例: 詠唱バー、ターゲットHPバー、インベントリウィジェット、ToDoリスト</value>
+	</data>
+	<data name="ModificationDescription_TargetCastBarCountdown" xml:space="preserve">
+		<value>ターゲットの詠唱バーに残り時間を追加表示します。</value>
+	</data>
+	<data name="ModificationDescription_SuppressDialogAdvance" xml:space="preserve">
+		<value>カットシーンのダイアログはウィンドウをクリックしたときのみ進行します。</value>
+	</data>
+	<data name="ModificationDescription_StickyShopCategories" xml:space="preserve">
+		<value>一部のショップで選択したカテゴリとサブカテゴリを記憶します。</value>
+	</data>
+	<data name="ModificationDescription_SkipTeleportConfirm" xml:space="preserve">
+		<value>マップからテレポートする際の「[地点]へ[ギル]で移動しますか？」確認をスキップします。</value>
+	</data>
+	<data name="ModificationDescription_ShowAetherCurrents" xml:space="preserve">
+		<value>マップ上にすべての風脈の泉を表示します。</value>
+	</data>
+	<data name="ModificationDescription_SelectNextLootItem" xml:space="preserve">
+		<value>Need/Greed/Passを押したあと自動で次の戦利品にフォーカスします。
+
+※自動でロットは行いません。</value>
+	</data>
+	<data name="ModificationDescription_SaddlebagSearchBar" xml:space="preserve">
+		<value>チョコボかばんに検索欄を追加します。</value>
+	</data>
+	<data name="ModificationDescription_RetainerSearchBar" xml:space="preserve">
+		<value>リテイナーウィンドウに検索欄を追加します。</value>
+	</data>
+	<data name="ModificationDescription_ResourceBarPercentages" xml:space="preserve">
+		<value>HP/MP/GP/CPバーを数値ではなくパーセンテージ表示に変更します。</value>
+	</data>
+	<data name="ModificationDescription_ResetInventoryTab" xml:space="preserve">
+		<value>インベントリを開くたびに最初のタブへ戻します。</value>
+	</data>
+	<data name="ModificationDescription_RecentlyLootedWindow" xml:space="preserve">
+		<value>ログイン中に入手したアイテムをスクロールリストで表示するウィンドウを追加します。
+
+機能有効後に入手したアイテムのみ表示されます。</value>
+	</data>
+	<data name="ModificationDescription_QuestListWindow" xml:space="preserve">
+		<value>現在のゾーンで受注可能なクエストを一覧表示します。</value>
+	</data>
+	<data name="ModificationDescription_OpenGlamourDresserToCurrentJob" xml:space="preserve">
+		<value>幻影タンスを開いた際、現在のジョブのタブを自動選択します。</value>
+	</data>
+	<data name="ModificationDescription_HideGuildhestObjectivePopup" xml:space="preserve">
+		<value>ギルドオーダー開始時に表示される手順ポップアップを抑制します。
+
+初めてのギルドオーダーの場合は無効化を推奨します。</value>
+	</data>
+	<data name="ModificationDescription_HideMpBars" xml:space="preserve">
+		<value>MPを使用しないジョブのパーティリストからMPバーを隠します。</value>
+	</data>
+	<data name="ModificationDescription_HideUnwantedBanners" xml:space="preserve">
+		<value>大型テキストバナーとそのSEを非表示にします。</value>
+	</data>
+	<data name="ModificationDescription_HUDCoordinates" xml:space="preserve">
+		<value>HUDレイアウトノードに座標を表示し、正確な配置を支援します。
+
+座標はHUD要素の中心を基準とします。</value>
+	</data>
+	<data name="ModificationDescription_InstancedWaymarks" xml:space="preserve">
+		<value>コンテンツごとにウェイマーカー保存枠を個別化し、各枠に名前を付けられます。</value>
+	</data>
+	<data name="ModificationDescription_InventorySearchBar" xml:space="preserve">
+		<value>インベントリウィンドウに検索欄を追加します。</value>
+	</data>
+	<data name="ModificationDescription_ListInventory" xml:space="preserve">
+		<value>インベントリを一覧表示し、フィルターを切り替えられるウィンドウを追加します。</value>
+	</data>
+	<data name="ModificationDescription_LocationDisplay" xml:space="preserve">
+		<value>サーバー情報バーに現在地を表示します。</value>
+	</data>
+	<data name="ModificationDescription_MacroLineNumbers" xml:space="preserve">
+		<value>ユーザーマクロウィンドウに行番号を表示します。</value>
+	</data>
+	<data name="ModificationDescription_MacroTooltips" xml:space="preserve">
+		<value>マクロに /macroicon アクションを設定している場合、ホバーでアクションのツールチップを表示します。</value>
+	</data>
+	<data name="ModificationDescription_DebugCustomAddon" xml:space="preserve">
+		<value>VanillaPlus 機能をテストするためのデバッグモジュール</value>
+	</data>
+	<data name="ModificationDescription_DebugGameModification" xml:space="preserve">
+		<value>VanillaPlus 機能をテストするためのデバッグモジュール</value>
+	</data>
+	<data name="ModificationDescription_SampleGameModification" xml:space="preserve">
+		<value>サンプル説明</value>
+	</data>
+	<data name="ModificationDescription_BetterCursor" xml:space="preserve">
+		<value>カーソルを取り巻くリングを描画し、視認性を向上させます。</value>
+	</data>
+	<data name="ModificationDescription_BetterInterruptableCastBars" xml:space="preserve">
+		<value>敵の割り込み可能な詠唱バーを目立たせます。
+
+割り込みできるアクションはホットバー上でも強調表示されます。</value>
+	</data>
+	<data name="ModificationDescription_BetterQuestMapLink" xml:space="preserve">
+		<value>クエストリンクをクリックした際、そのクエスト専用マップを開きます。</value>
+	</data>
+	<data name="ModificationDescription_CastBarAetheryteNames" xml:space="preserve">
+		<value>「テレポ」の詠唱名を目的地のエーテライト名に置き換えます。</value>
+	</data>
+	<data name="ModificationDescription_CurrencyOverlay" xml:space="preserve">
+		<value>UIオーバーレイに追加の通貨を表示できます。
+
+警告を出す最小値と最大値も設定可能です。</value>
+	</data>
+	<data name="ModificationDescription_DraggableWindowDeadSpace" xml:space="preserve">
+		<value>ウィンドウの余白をドラッグして移動できるようにします。</value>
+	</data>
+	<data name="ModificationDescription_DutyTimer" xml:space="preserve">
+		<value>コンテンツ完了時に所要時間をチャットへ出力します。</value>
+	</data>
+	<data name="ModificationDescription_DutyLootPreview" xml:space="preserve">
+		<value>コンテンツウィンドウに戦利品ビューアーを追加します。</value>
+	</data>
+	<data name="ModificationDescription_EnhancedLootWindow" xml:space="preserve">
+		<value>戦利品ウィンドウにそのアイテムを解放済みか入手可能かの指標を表示します。</value>
+	</data>
+	<data name="ModificationDescription_FadeLootButton" xml:space="preserve">
+		<value>すべてのアイテムでロット済みの場合、Lootボタンを淡くします。</value>
+	</data>
+	<data name="ModificationDescription_FadeUnavailableActions" xml:space="preserve">
+		<value>リソース不足、射程外、リキャスト中などで使用できないアクションのホットバーをフェードさせます。
+
+レベルシンクで使用不可になったアクションもフェードします。</value>
+	</data>
+	<data name="ModificationDescription_FasterScroll" xml:space="preserve">
+		<value>すべてのスクロールバー速度を上げます。</value>
+	</data>
+	<data name="ModificationDescription_FastMouseClick" xml:space="preserve">
+		<value>ゲームはダブルクリック時にシングルクリックイベントを送信しません。
+
+この機能はダブルクリック時にもシングルクリックを発生させます。</value>
+	</data>
+	<data name="ModificationDescription_FocusTargetLock" xml:space="preserve">
+		<value>コンテンツ再開時に以前のフォーカスターゲットを復元します。</value>
+	</data>
+	<data name="ModificationDescription_ForcedCutsceneSounds" xml:space="preserve">
+		<value>カットシーン中に選択したサウンドチャネルのミュートを自動解除します。</value>
+	</data>
+	<data name="ModificationDescription_HUDPresets" xml:space="preserve">
+		<value>無制限にHUDレイアウトを保存/読み込みできます。</value>
+	</data>
+	<data name="ModificationDescription_FateListWindow" xml:space="preserve">
+		<value>現在のゾーンで進行中のFATEをすべて表示します。</value>
+	</data>
+	<data name="ModificationDescription_PetSizeContextMenu" xml:space="preserve">
+		<value>ペットまたはペットを連れるプレイヤーを右クリックするとサイズ変更メニューを表示します。</value>
+	</data>
+	<data name="ModificationDescription_MissingJobStoneLockout" xml:space="preserve">
+		<value>ソウルクリスタル未装備時はコンテンツ申請をブロックします。</value>
+	</data>
+	<data name="ModificationDescription_GearsetRedirect" xml:space="preserve">
+		<value>ゾーンに応じて別のギアセットを読み込むように設定できます。</value>
+	</data>
+	<data name="ModificationDisplay_ArmourySearchBar" xml:space="preserve">
+		<value>アーマリー検索バー</value>
+	</data>
+	<data name="ModificationDisplay_ClearFlag" xml:space="preserve">
+		<value>旗を消去</value>
+	</data>
+	<data name="ModificationDisplay_ClearSelectedDuties" xml:space="preserve">
+		<value>コンテンツ選択解除</value>
+	</data>
+	<data name="ModificationDisplay_ClearTextInputs" xml:space="preserve">
+		<value>テキスト入力クリア</value>
+	</data>
+	<data name="ModificationDisplay_WondrousTailsProbabilities" xml:space="preserve">
+		<value>ワンダラーテイルズ確率</value>
+	</data>
+	<data name="WondrousTailsProbabilities_ErrorPlaceholder" xml:space="preserve">
+		<value>エラー </value>
+	</data>
+	<data name="WondrousTailsProbabilities_LineChancesLabel" xml:space="preserve">
+		<value>ライン確率： </value>
+	</data>
+	<data name="WondrousTailsProbabilities_ShuffleAverageLabel" xml:space="preserve">
+		<value>シャッフル平均： </value>
+	</data>
+	<data name="AddonConfig_KeybindWindowTitle" xml:space="preserve">
+		<value>キーバインド設定ウィンドウ</value>
+	</data>
+	<data name="AddonConfig_KeybindLabel" xml:space="preserve">
+		<value>キーバインド</value>
+	</data>
+	<data name="Common_Disable" xml:space="preserve">
+		<value>無効化</value>
+	</data>
+	<data name="Common_Enable" xml:space="preserve">
+		<value>有効化</value>
+	</data>
+	<data name="AddonConfig_ChangeKeybind" xml:space="preserve">
+		<value>キーバインドを変更</value>
+	</data>
+	<data name="AddonConfig_WindowSizeLabel" xml:space="preserve">
+		<value>ウィンドウサイズ</value>
+	</data>
+	<data name="AddonConfig_WindowWidthLabel" xml:space="preserve">
+		<value>幅</value>
+	</data>
+	<data name="AddonConfig_WindowHeightLabel" xml:space="preserve">
+		<value>高さ</value>
+	</data>
+	<data name="AddonConfig_ReloadHint" xml:space="preserve">
+		<value>変更はウィンドウを開き直すまで適用されません</value>
+	</data>
+	<data name="KeybindConfig_InputPrompt" xml:space="preserve">
+		<value>希望するキーコンボを入力</value>
+	</data>
+	<data name="KeybindConfig_CurrentPrompt" xml:space="preserve">
+		<value>キーコンボを押してください</value>
+	</data>
+	<data name="KeybindConfig_ConflictsLabel" xml:space="preserve">
+		<value>競合するキーバインド</value>
+	</data>
+	<data name="KeybindConfig_NoConflicts" xml:space="preserve">
+		<value>競合は検出されませんでした</value>
+	</data>
+	<data name="Common_Confirm" xml:space="preserve">
+		<value>決定</value>
+	</data>
+	<data name="Common_Cancel" xml:space="preserve">
+		<value>キャンセル</value>
+	</data>
+	<data name="NodeList_ConfigWindowTitle" xml:space="preserve">
+		<value>{0} 設定ウィンドウ</value>
+	</data>
+	<data name="NodeList_OpenCommandHelp" xml:space="preserve">
+		<value>{0} ウィンドウを開きます</value>
+	</data>
+	<data name="SearchAddon_GearsetTitle" xml:space="preserve">
+		<value>ギアセット検索</value>
+	</data>
+	<data name="SortOption_Alphabetical" xml:space="preserve">
+		<value>五十音順</value>
+	</data>
+	<data name="SortOption_Id" xml:space="preserve">
+		<value>ID順</value>
+	</data>
+	<data name="SearchAddon_TerritoryTitle" xml:space="preserve">
+		<value>エリア検索</value>
+	</data>
+	<data name="ColorPicker_WindowTitle" xml:space="preserve">
+		<value>カラーピッカー</value>
+	</data>
+	<data name="NodeStyle_PositionLabel" xml:space="preserve">
+		<value>位置</value>
+	</data>
+	<data name="TextNodeConfig_TextColor" xml:space="preserve">
+		<value>文字色</value>
+	</data>
+	<data name="TextNodeConfig_TextOutline" xml:space="preserve">
+		<value>文字縁</value>
+	</data>
+	<data name="TextNodeConfig_FontSize" xml:space="preserve">
+		<value>フォントサイズ</value>
+	</data>
+	<data name="TextNodeConfig_Font" xml:space="preserve">
+		<value>フォント</value>
+	</data>
+	<data name="TextNodeConfig_Alignment" xml:space="preserve">
+		<value>配置</value>
+	</data>
+	<data name="IconWithCount_MillionsFormat" xml:space="preserve">
+		<value>{0}m</value>
+	</data>
+	<data name="IconWithCount_ThousandsFormat" xml:space="preserve">
+		<value>{0}k</value>
+	</data>
+	<data name="ModificationDisplay_WindowBackground" xml:space="preserve">
+		<value>ウィンドウ背景</value>
+	</data>
+	<data name="ModificationDisplay_TargetCastBarCountdown" xml:space="preserve">
+		<value>ターゲット詠唱バー残り時間</value>
+	</data>
+	<data name="ModificationDisplay_SuppressDialogAdvance" xml:space="preserve">
+		<value>ダイアログ抑制</value>
+	</data>
+	<data name="ModificationDisplay_StickyShopCategories" xml:space="preserve">
+		<value>ショップカテゴリ記憶</value>
+	</data>
+	<data name="ModificationDisplay_SkipTeleportConfirm" xml:space="preserve">
+		<value>テレポ確認スキップ</value>
+	</data>
+	<data name="ModificationDisplay_ShowAetherCurrents" xml:space="preserve">
+		<value>風脈の泉表示</value>
+	</data>
+	<data name="ModificationDisplay_SelectNextLootItem" xml:space="preserve">
+		<value>次の戦利品へ移動</value>
+	</data>
+	<data name="ModificationDisplay_SaddlebagSearchBar" xml:space="preserve">
+		<value>チョコボかばん検索</value>
+	</data>
+	<data name="ModificationDisplay_RetainerSearchBar" xml:space="preserve">
+		<value>リテイナー検索</value>
+	</data>
+	<data name="ModificationDisplay_ResourceBarPercentages" xml:space="preserve">
+		<value>リソース%表示</value>
+	</data>
+	<data name="ModificationDisplay_ResetInventoryTab" xml:space="preserve">
+		<value>インベントリタブ初期化</value>
+	</data>
+	<data name="ModificationDisplay_RecentlyLootedWindow" xml:space="preserve">
+		<value>最近の戦利品ウィンドウ</value>
+	</data>
+	<data name="ModificationDisplay_QuestListWindow" xml:space="preserve">
+		<value>クエストリストウィンドウ</value>
+	</data>
+	<data name="ModificationDisplay_OpenGlamourDresserToCurrentJob" xml:space="preserve">
+		<value>幻影タンス自動タブ</value>
+	</data>
+	<data name="ModificationDisplay_HideGuildhestObjectivePopup" xml:space="preserve">
+		<value>ギルドオーダーポップ非表示</value>
+	</data>
+	<data name="ModificationDisplay_HideMpBars" xml:space="preserve">
+		<value>MPバー非表示</value>
+	</data>
+	<data name="ModificationDisplay_HideUnwantedBanners" xml:space="preserve">
+		<value>バナー非表示</value>
+	</data>
+	<data name="ModificationDisplay_HUDCoordinates" xml:space="preserve">
+		<value>HUD座標</value>
+	</data>
+	<data name="ModificationDisplay_InstancedWaymarks" xml:space="preserve">
+		<value>個別ウェイマーカー</value>
+	</data>
+	<data name="ModificationDisplay_InventorySearchBar" xml:space="preserve">
+		<value>インベントリ検索バー</value>
+	</data>
+	<data name="ModificationDisplay_ListInventory" xml:space="preserve">
+		<value>インベントリ一覧</value>
+	</data>
+	<data name="ModificationDisplay_LocationDisplay" xml:space="preserve">
+		<value>ロケーション表示</value>
+	</data>
+	<data name="ModificationDisplay_MacroLineNumbers" xml:space="preserve">
+		<value>マクロ行番号</value>
+	</data>
+	<data name="ModificationDisplay_MacroTooltips" xml:space="preserve">
+		<value>マクロツールチップ</value>
+	</data>
+	<data name="ModificationDisplay_DebugCustomAddon" xml:space="preserve">
+		<value>デバッグ CustomAddon</value>
+	</data>
+	<data name="ModificationDisplay_DebugGameModification" xml:space="preserve">
+		<value>デバッグ GameModification</value>
+	</data>
+	<data name="ModificationDisplay_SampleGameModification" xml:space="preserve">
+		<value>サンプル表示名</value>
+	</data>
+	<data name="ModificationDisplay_BetterCursor" xml:space="preserve">
+		<value>Better Cursor</value>
+	</data>
+	<data name="ModificationDisplay_BetterInterruptableCastBars" xml:space="preserve">
+		<value>割り込み詠唱バー強調</value>
+	</data>
+	<data name="ModificationDisplay_BetterQuestMapLink" xml:space="preserve">
+		<value>クエストマップリンク改善</value>
+	</data>
+	<data name="ModificationDisplay_CastBarAetheryteNames" xml:space="preserve">
+		<value>詠唱バーに目的地名</value>
+	</data>
+	<data name="ModificationDisplay_CurrencyOverlay" xml:space="preserve">
+		<value>通貨オーバーレイ</value>
+	</data>
+	<data name="ModificationDisplay_DraggableWindowDeadSpace" xml:space="preserve">
+		<value>デッドスペースドラッグ</value>
+	</data>
+	<data name="ModificationDisplay_DutyTimer" xml:space="preserve">
+		<value>コンテンツタイマー</value>
+	</data>
+	<data name="ModificationDisplay_DutyLootPreview" xml:space="preserve">
+		<value>戦利品プレビュー</value>
+	</data>
+	<data name="ModificationDisplay_EnhancedLootWindow" xml:space="preserve">
+		<value>戦利品ウィンドウ強化</value>
+	</data>
+	<data name="ModificationDisplay_FadeLootButton" xml:space="preserve">
+		<value>Lootボタンフェード</value>
+	</data>
+	<data name="ModificationDisplay_FadeUnavailableActions" xml:space="preserve">
+		<value>使用不可アクションフェード</value>
+	</data>
+	<data name="ModificationDisplay_FasterScroll" xml:space="preserve">
+		<value>高速スクロール</value>
+	</data>
+	<data name="ModificationDisplay_FastMouseClick" xml:space="preserve">
+		<value>高速マウスクリック</value>
+	</data>
+	<data name="ModificationDisplay_FocusTargetLock" xml:space="preserve">
+		<value>フォーカスターゲット維持</value>
+	</data>
+	<data name="ModificationDisplay_ForcedCutsceneSounds" xml:space="preserve">
+		<value>カットシーン音声強制</value>
+	</data>
+	<data name="ModificationDisplay_HUDPresets" xml:space="preserve">
+		<value>HUDプリセット</value>
+	</data>
+	<data name="ModificationDisplay_FateListWindow" xml:space="preserve">
+		<value>FATEリストウィンドウ</value>
+	</data>
+	<data name="ModificationDisplay_PetSizeContextMenu" xml:space="preserve">
+		<value>ペットサイズメニュー</value>
+	</data>
+	<data name="PetSize_MenuTitle" xml:space="preserve">
+		<value>ペットサイズ</value>
+	</data>
+	<data name="PetSize_OptionLarge" xml:space="preserve">
+		<value>大</value>
+	</data>
+	<data name="PetSize_OptionMedium" xml:space="preserve">
+		<value>中</value>
+	</data>
+	<data name="PetSize_OptionSmall" xml:space="preserve">
+		<value>小</value>
+	</data>
+	<data name="ModificationDisplay_MissingJobStoneLockout" xml:space="preserve">
+		<value>ソウルクリスタルロック</value>
+	</data>
+	<data name="ModificationDisplay_GearsetRedirect" xml:space="preserve">
+		<value>ギアセットリダイレクト</value>
+	</data>
+	<data name="EnhancedLootWindow_CategorySettings" xml:space="preserve">
+		<value>設定</value>
+	</data>
+	<data name="EnhancedLootWindow_ConfigTitle" xml:space="preserve">
+		<value>戦利品ウィンドウ拡張設定</value>
+	</data>
+	<data name="EnhancedLootWindow_LabelMarkAlreadyObtained" xml:space="preserve">
+		<value>入手済みアイテムをマークする</value>
+	</data>
+	<data name="EnhancedLootWindow_LabelMarkUnobtainable" xml:space="preserve">
+		<value>入手できないアイテムをマークする</value>
+	</data>
+	<data name="FadeLootButton_CategoryStyleSettings" xml:space="preserve">
+		<value>スタイル設定</value>
+	</data>
+	<data name="FadeLootButton_ConfigTitle" xml:space="preserve">
+		<value>Lootボタンフェード設定</value>
+	</data>
+	<data name="FadeLootButton_LabelFadePercentage" xml:space="preserve">
+		<value>フェード率</value>
+	</data>
+	<data name="FadeUnavailableActions_CategoryFeatureToggles" xml:space="preserve">
+		<value>機能切り替え</value>
+	</data>
+	<data name="FadeUnavailableActions_CategoryStyleSettings" xml:space="preserve">
+		<value>スタイル設定</value>
+	</data>
+	<data name="FadeUnavailableActions_ConfigTitle" xml:space="preserve">
+		<value>使用不可アクションフェード設定</value>
+	</data>
+	<data name="FadeUnavailableActions_LabelApplyToFrame" xml:space="preserve">
+		<value>枠にも透過を適用</value>
+	</data>
+	<data name="FadeUnavailableActions_LabelApplyToSync" xml:space="preserve">
+		<value>シンク対象アクションのみに適用</value>
+	</data>
+	<data name="FadeUnavailableActions_LabelFadePercentage" xml:space="preserve">
+		<value>フェード率</value>
+	</data>
+	<data name="FadeUnavailableActions_LabelReddenOutOfRange" xml:space="preserve">
+		<value>射程外で赤くする</value>
+	</data>
+	<data name="FadeUnavailableActions_LabelReddenPercentage" xml:space="preserve">
+		<value>赤みの強さ</value>
+	</data>
+	<data name="FasterScroll_CategorySettings" xml:space="preserve">
+		<value>設定</value>
+	</data>
+	<data name="FasterScroll_ConfigTitle" xml:space="preserve">
+		<value>高速スクロール設定</value>
+	</data>
+	<data name="FasterScroll_LabelSpeedMultiplier" xml:space="preserve">
+		<value>速度倍率</value>
+	</data>
+	<data name="ForcedCutsceneSounds_CategoryGeneral" xml:space="preserve">
+		<value>一般</value>
+	</data>
+	<data name="ForcedCutsceneSounds_CategorySpecial" xml:space="preserve">
+		<value>特殊</value>
+	</data>
+	<data name="ForcedCutsceneSounds_CategoryToggles" xml:space="preserve">
+		<value>切り替え</value>
+	</data>
+	<data name="ForcedCutsceneSounds_ConfigTitle" xml:space="preserve">
+		<value>カットシーン音声強制設定</value>
+	</data>
+	<data name="ForcedCutsceneSounds_DisableMsq" xml:space="preserve">
+		<value>討滅/メインルレでは無効</value>
+	</data>
+	<data name="ForcedCutsceneSounds_RestoreMuteState" xml:space="preserve">
+		<value>終了後にミュート状態を戻す</value>
+	</data>
+	<data name="ForcedCutsceneSounds_UnmuteBgm" xml:space="preserve">
+		<value>BGMのミュートを解除</value>
+	</data>
+	<data name="ForcedCutsceneSounds_UnmuteEnv" xml:space="preserve">
+		<value>環境音のミュートを解除</value>
+	</data>
+	<data name="ForcedCutsceneSounds_UnmuteMaster" xml:space="preserve">
+		<value>マスター音量のミュートを解除</value>
+	</data>
+	<data name="ForcedCutsceneSounds_UnmutePerform" xml:space="preserve">
+		<value>演奏のミュートを解除</value>
+	</data>
+	<data name="ForcedCutsceneSounds_UnmuteSe" xml:space="preserve">
+		<value>効果音のミュートを解除</value>
+	</data>
+	<data name="ForcedCutsceneSounds_UnmuteSystem" xml:space="preserve">
+		<value>システム音のミュートを解除</value>
+	</data>
+	<data name="ForcedCutsceneSounds_UnmuteVoice" xml:space="preserve">
+		<value>ボイスのミュートを解除</value>
+	</data>
+	<data name="GearsetRedirect_ConfigTitle" xml:space="preserve">
+		<value>ギアセットリダイレクト設定</value>
+	</data>
+	<data name="GearsetRedirect_AddRedirectionTitle" xml:space="preserve">
+		<value>新しいリダイレクトを追加</value>
+	</data>
+	<data name="GearsetRedirect_SortAlphabetical" xml:space="preserve">
+		<value>五十音順</value>
+	</data>
+	<data name="GearsetRedirect_SortId" xml:space="preserve">
+		<value>ID順</value>
+	</data>
+	<data name="HideUnwantedBanners_ConfigTitle" xml:space="preserve">
+		<value>バナー非表示設定</value>
+	</data>
+	<data name="InstancedWaymarks_RenameMenuLabel" xml:space="preserve">
+		<value>名前を変更</value>
+	</data>
+	<data name="InstancedWaymarks_RenameWindowTitle" xml:space="preserve">
+		<value>ウェイマーカー名称変更</value>
+	</data>
+	<data name="DebugCustomAddon_Title" xml:space="preserve">
+		<value>デバッグアドオンウィンドウ</value>
+	</data>
+	<data name="ResourceBarPercentages_ApplyToPartyMembers" xml:space="preserve">
+		<value>パーティメンバーに適用</value>
+	</data>
+	<data name="ResourceBarPercentages_ApplyToPlayer" xml:space="preserve">
+		<value>自キャラに適用</value>
+	</data>
+	<data name="ResourceBarPercentages_CategoryExtra" xml:space="preserve">
+		<value>その他</value>
+	</data>
+	<data name="ResourceBarPercentages_CategoryParameterWidget" xml:space="preserve">
+		<value>パラメータウィジェット</value>
+	</data>
+	<data name="ResourceBarPercentages_CategoryPartyList" xml:space="preserve">
+		<value>パーティリスト</value>
+	</data>
+	<data name="ResourceBarPercentages_CategoryPercentageFormat" xml:space="preserve">
+		<value>パーセント表示形式</value>
+	</data>
+	<data name="ResourceBarPercentages_CategoryPercentageSign" xml:space="preserve">
+		<value>パーセント記号</value>
+	</data>
+	<data name="ResourceBarPercentages_ChangeCp" xml:space="preserve">
+		<value>CPの表示を変更</value>
+	</data>
+	<data name="ResourceBarPercentages_ChangeGp" xml:space="preserve">
+		<value>GPの表示を変更</value>
+	</data>
+	<data name="ResourceBarPercentages_ChangeHp" xml:space="preserve">
+		<value>HPの表示を変更</value>
+	</data>
+	<data name="ResourceBarPercentages_ChangeMp" xml:space="preserve">
+		<value>MPの表示を変更</value>
+	</data>
+	<data name="ResourceBarPercentages_ConfigTitle" xml:space="preserve">
+		<value>リソース%表示設定</value>
+	</data>
+	<data name="ResourceBarPercentages_DecimalPlaces" xml:space="preserve">
+		<value>小数点以下桁数</value>
+	</data>
+	<data name="ResourceBarPercentages_DeadOrAliveMode" xml:space="preserve">
+		<value>生存/戦闘不能モード</value>
+	</data>
+	<data name="ResourceBarPercentages_ShowDecimalsBelowHundred" xml:space="preserve">
+		<value>100%未満のみ小数を表示</value>
+	</data>
+	<data name="ResourceBarPercentages_ShowOnParameterWidget" xml:space="preserve">
+		<value>パラメータウィジェットに表示</value>
+	</data>
+	<data name="ResourceBarPercentages_ShowOnPartyList" xml:space="preserve">
+		<value>パーティリストに表示</value>
+	</data>
+	<data name="ResourceBarPercentages_ShowPercentageSign" xml:space="preserve">
+		<value>%記号を表示</value>
+	</data>
+	<data name="ResourceBarPercentages_StatusAlive" xml:space="preserve">
+		<value>生存</value>
+	</data>
+	<data name="ResourceBarPercentages_StatusDead" xml:space="preserve">
+		<value>戦闘不能</value>
+	</data>
+	<data name="ListInventory_Title" xml:space="preserve">
+		<value>インベントリ一覧</value>
+	</data>
+	<data name="ListInventory_FilterAlphabetically" xml:space="preserve">
+		<value>五十音順</value>
+	</data>
+	<data name="ListInventory_FilterQuantity" xml:space="preserve">
+		<value>数量</value>
+	</data>
+	<data name="ListInventory_FilterLevel" xml:space="preserve">
+		<value>レベル</value>
+	</data>
+	<data name="ListInventory_FilterItemLevel" xml:space="preserve">
+		<value>アイテムレベル</value>
+	</data>
+	<data name="ListInventory_FilterRarity" xml:space="preserve">
+		<value>レアリティ</value>
+	</data>
+	<data name="ListInventory_FilterItemId" xml:space="preserve">
+		<value>アイテムID</value>
+	</data>
+	<data name="ListInventory_FilterItemCategory" xml:space="preserve">
+		<value>アイテムカテゴリ</value>
+	</data>
+	<data name="RecentlyLootedWindow_Title" xml:space="preserve">
+		<value>最近の戦利品</value>
+	</data>
+	<data name="QuestListWindow_Title" xml:space="preserve">
+		<value>クエストリスト</value>
+	</data>
+	<data name="QuestListWindow_FilterAlphabetically" xml:space="preserve">
+		<value>五十音順</value>
+	</data>
+	<data name="QuestListWindow_FilterDistance" xml:space="preserve">
+		<value>距離</value>
+	</data>
+	<data name="QuestListWindow_FilterIssuerName" xml:space="preserve">
+		<value>依頼主名</value>
+	</data>
+	<data name="QuestListWindow_FilterLevel" xml:space="preserve">
+		<value>レベル</value>
+	</data>
+	<data name="QuestListWindow_FilterType" xml:space="preserve">
+		<value>種類</value>
+	</data>
+	<data name="ShowAetherCurrents_Tooltip" xml:space="preserve">
+		<value>風脈の泉</value>
+	</data>
+	<data name="Title_DutyLootPreview" xml:space="preserve">
+		<value>戦利品プレビュー</value>
+	</data>
+	<data name="VersionLabelFormat" xml:space="preserve">
+		<value>バージョン {0}</value>
+	</data>
+</root>

--- a/VanillaPlus/Resources/Strings.resx
+++ b/VanillaPlus/Resources/Strings.resx
@@ -1,0 +1,1124 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+	<xsd:schema id="root" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+		<xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+		<xsd:element name="root" msdata:IsDataSet="true">
+			<xsd:complexType>
+				<xsd:choice maxOccurs="unbounded">
+					<xsd:element name="metadata">
+						<xsd:complexType>
+							<xsd:sequence>
+								<xsd:element name="value" type="xsd:string" minOccurs="0" />
+							</xsd:sequence>
+							<xsd:attribute name="name" use="required" type="xsd:string" />
+							<xsd:attribute name="type" type="xsd:string" />
+							<xsd:attribute name="mimetype" type="xsd:string" />
+							<xsd:attribute ref="xml:space" />
+						</xsd:complexType>
+					</xsd:element>
+					<xsd:element name="assembly">
+						<xsd:complexType>
+							<xsd:attribute name="alias" type="xsd:string" />
+							<xsd:attribute name="name" type="xsd:string" />
+						</xsd:complexType>
+					</xsd:element>
+					<xsd:element name="data">
+						<xsd:complexType>
+							<xsd:sequence>
+								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+								<xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+							</xsd:sequence>
+							<xsd:attribute name="name" type="xsd:string" use="required" />
+							<xsd:attribute name="type" type="xsd:string" />
+							<xsd:attribute name="mimetype" type="xsd:string" />
+							<xsd:attribute ref="xml:space" />
+						</xsd:complexType>
+					</xsd:element>
+					<xsd:element name="resheader">
+						<xsd:complexType>
+							<xsd:sequence>
+								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+							</xsd:sequence>
+							<xsd:attribute name="name" type="xsd:string" use="required" />
+						</xsd:complexType>
+					</xsd:element>
+				</xsd:choice>
+			</xsd:complexType>
+		</xsd:element>
+	</xsd:schema>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>2.0</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<data name="Button_SavePreset" xml:space="preserve">
+		<value>Save Preset</value>
+	</data>
+	<data name="ChangelogBrowserTitle" xml:space="preserve">
+		<value>Vanilla Plus Changelog Browser</value>
+	</data>
+	<data name="ChangelogButtonLabel" xml:space="preserve">
+		<value>Changelog</value>
+	</data>
+	<data name="ChangelogTitleFormat" xml:space="preserve">
+		<value>{0} Changelog</value>
+	</data>
+	<data name="CommandHelpOpenBrowser" xml:space="preserve">
+		<value>Open Game Modification Browser</value>
+	</data>
+	<data name="ConfigCategory_Animations" xml:space="preserve">
+		<value>Animations</value>
+	</data>
+	<data name="ConfigCategory_Colors" xml:space="preserve">
+		<value>Colors</value>
+	</data>
+	<data name="ConfigCategory_Icon" xml:space="preserve">
+		<value>Icon</value>
+	</data>
+	<data name="ConfigLabel_ButtonColor" xml:space="preserve">
+		<value>Button</value>
+	</data>
+	<data name="ConfigLabel_EnableAnimations" xml:space="preserve">
+		<value>Enable Animations</value>
+	</data>
+	<data name="ConfigLabel_Icon" xml:space="preserve">
+		<value>Icon</value>
+	</data>
+	<data name="ConfigLabel_LaneColor" xml:space="preserve">
+		<value>Lane</value>
+	</data>
+	<data name="BetterCursor_CategoryFunctions" xml:space="preserve">
+		<value>Functions</value>
+	</data>
+	<data name="BetterCursor_CategoryIconSelection" xml:space="preserve">
+		<value>Icon Selection</value>
+	</data>
+	<data name="BetterCursor_CategoryStyle" xml:space="preserve">
+		<value>Style</value>
+	</data>
+	<data name="BetterCursor_CategoryVisibility" xml:space="preserve">
+		<value>Visibility</value>
+	</data>
+	<data name="BetterCursor_ConfigTitle" xml:space="preserve">
+		<value>Better Cursor Config</value>
+	</data>
+	<data name="BetterCursor_EnableAnimation" xml:space="preserve">
+		<value>Enable Animation</value>
+	</data>
+	<data name="BetterCursor_HideOnCameraMove" xml:space="preserve">
+		<value>Hide on Left-Hold or Right-Hold</value>
+	</data>
+	<data name="BetterCursor_LabelColor" xml:space="preserve">
+		<value>Color</value>
+	</data>
+	<data name="BetterCursor_LabelIcon" xml:space="preserve">
+		<value>Icon</value>
+	</data>
+	<data name="BetterCursor_LabelSize" xml:space="preserve">
+		<value>Size</value>
+	</data>
+	<data name="BetterCursor_OnlyShowInCombat" xml:space="preserve">
+		<value>Only show in Combat</value>
+	</data>
+	<data name="BetterCursor_OnlyShowInDuties" xml:space="preserve">
+		<value>Only Show in Duties</value>
+	</data>
+	<data name="CurrencyOverlay_ConfigTitle" xml:space="preserve">
+		<value>Currency Overlay Config</value>
+	</data>
+	<data name="CurrencyOverlay_ItemSearchTitle" xml:space="preserve">
+		<value>Item Search</value>
+	</data>
+	<data name="CurrencyOverlay_SortOptionAlphabetical" xml:space="preserve">
+		<value>Alphabetical</value>
+	</data>
+	<data name="CurrencyOverlay_SortOptionId" xml:space="preserve">
+		<value>Id</value>
+	</data>
+	<data name="WindowBackground_ConfigTitle" xml:space="preserve">
+		<value>Window Backgrounds Config</value>
+	</data>
+	<data name="WindowBackground_SearchTitle" xml:space="preserve">
+		<value>Window Search</value>
+	</data>
+	<data name="WindowBackground_SortOptionAlphabetical" xml:space="preserve">
+		<value>Alphabetical</value>
+	</data>
+	<data name="WindowBackground_SortOptionVisibility" xml:space="preserve">
+		<value>Visibility</value>
+	</data>
+	<data name="WindowBackground_ColorPickerTitle" xml:space="preserve">
+		<value>Window Background Color Picker</value>
+	</data>
+	<data name="WindowBackground_CategoryBackgroundColor" xml:space="preserve">
+		<value>Background Color</value>
+	</data>
+	<data name="WindowBackground_ColorLabel" xml:space="preserve">
+		<value>Color</value>
+	</data>
+	<data name="WindowBackground_CategoryPaddingSize" xml:space="preserve">
+		<value>Padding Size</value>
+	</data>
+	<data name="TargetCastBarCountdown_CategoryFocusStyle" xml:space="preserve">
+		<value>Focus Target Castbar Style</value>
+	</data>
+	<data name="TargetCastBarCountdown_CategoryNameplateStyle" xml:space="preserve">
+		<value>Nameplate Castbar Style</value>
+	</data>
+	<data name="TargetCastBarCountdown_CategoryPrimaryAltStyle" xml:space="preserve">
+		<value>Target Castbar Style (Separate)</value>
+	</data>
+	<data name="TargetCastBarCountdown_CategoryPrimaryStyle" xml:space="preserve">
+		<value>Target Castbar Style (Combined)</value>
+	</data>
+	<data name="TargetCastBarCountdown_CategoryToggles" xml:space="preserve">
+		<value>Toggles</value>
+	</data>
+	<data name="TargetCastBarCountdown_CheckboxFocus" xml:space="preserve">
+		<value>Show on Focus Target Castbar</value>
+	</data>
+	<data name="TargetCastBarCountdown_CheckboxNameplate" xml:space="preserve">
+		<value>Show on Nameplate Target Castbar</value>
+	</data>
+	<data name="TargetCastBarCountdown_CheckboxPrimary" xml:space="preserve">
+		<value>Show on Primary Target Castbar</value>
+	</data>
+	<data name="TargetCastBarCountdown_ConfigTitle" xml:space="preserve">
+		<value>Target Castbar Countdown Config</value>
+	</data>
+	<data name="SuppressDialogAdvance_ApplyOnlyInCutscenes" xml:space="preserve">
+		<value>Apply only in Cutscenes</value>
+	</data>
+	<data name="SuppressDialogAdvance_CategoryGeneral" xml:space="preserve">
+		<value>General</value>
+	</data>
+	<data name="SuppressDialogAdvance_ConfigTitle" xml:space="preserve">
+		<value>Suppress Dialog Advance Config</value>
+	</data>
+	<data name="ClearSelectedDuties_ConfigTitle" xml:space="preserve">
+		<value>Clear Selected Duties Config</value>
+	</data>
+	<data name="ClearSelectedDuties_DisableWhenUnrestricted" xml:space="preserve">
+		<value>Disable when Unrestricted</value>
+	</data>
+	<data name="ClearSelectedDuties_SettingsCategory" xml:space="preserve">
+		<value>Settings</value>
+	</data>
+	<data name="Label_ModAuthorBy" xml:space="preserve">
+		<value>By {0}</value>
+	</data>
+	<data name="ModificationBrowserTitle" xml:space="preserve">
+		<value>Vanilla Plus Modification Browser</value>
+	</data>
+	<data name="ModificationDescription_MiniCactpotHelper" xml:space="preserve">
+		<value>Indicates which Mini Cactpot spots you should reveal next.</value>
+	</data>
+	<data name="ModificationDescription_PartyFinderPresets" xml:space="preserve">
+		<value>Allows you to save and use presets for the Party Finder Recruitment window.</value>
+	</data>
+	<data name="ModificationDisplay_MiniCactpotHelper" xml:space="preserve">
+		<value>Mini Cactpot Helper</value>
+	</data>
+	<data name="ModificationDisplay_PartyFinderPresets" xml:space="preserve">
+		<value>Party Finder Presets</value>
+	</data>
+	<data name="Preset_DefaultOption" xml:space="preserve">
+		<value>No Presets Saved</value>
+	</data>
+	<data name="Preset_DontUseOption" xml:space="preserve">
+		<value>Don&apos;t Use Preset</value>
+	</data>
+	<data name="SearchPlaceholder" xml:space="preserve">
+		<value>Search . . .</value>
+	</data>
+	<data name="SelectionPrompt" xml:space="preserve">
+		<value>Please select an option on the left</value>
+	</data>
+	<data name="Title_MiniCactpotConfig" xml:space="preserve">
+		<value>Mini Cactpot Helper Config</value>
+	</data>
+	<data name="Title_PartyFinderPreset" xml:space="preserve">
+		<value>Party Finder Preset</value>
+	</data>
+	<data name="Title_PresetConfigManager" xml:space="preserve">
+		<value>Preset Config Manager</value>
+	</data>
+	<data name="Tooltip_ConfigEzMiniCactpot" xml:space="preserve">
+		<value>Configure EzMiniCactpot Plugin</value>
+	</data>
+	<data name="Tooltip_ExperimentalFeature" xml:space="preserve">
+		<value>Caution, this feature is experimental.
+May contain bugs or crash your game.</value>
+	</data>
+	<data name="Tooltip_ModificationFailedToLoad" xml:space="preserve">
+		<value>Failed to load, this module has been disabled</value>
+	</data>
+	<data name="Tooltip_NoPresets" xml:space="preserve">
+		<value>[VanillaPlus]: No presets saved</value>
+	</data>
+	<data name="Tooltip_OpenConfiguration" xml:space="preserve">
+		<value>Open configuration window</value>
+	</data>
+	<data name="Tooltip_ReverseSortDirection" xml:space="preserve">
+		<value>Reverse Sort Direction</value>
+	</data>
+	<data name="Tooltip_RetryCompatibility" xml:space="preserve">
+		<value>Retry compatibility check</value>
+	</data>
+	<data name="Tooltip_SavePreset" xml:space="preserve">
+		<value>[VanillaPlus]: Save current settings to a preset</value>
+	</data>
+	<data name="Tooltip_SearchRegexSupport" xml:space="preserve">
+		<value>[VanillaPlus]: Supports Regex Search
+Start input with &apos;$&apos; to search by description</value>
+	</data>
+	<data name="Tooltip_SelectPreset" xml:space="preserve">
+		<value>[VanillaPlus]: Select a preset</value>
+	</data>
+	<data name="DutyTimer_CompletedMessage" xml:space="preserve">
+		<value>Duty Completed in: {0}</value>
+	</data>
+	<data name="DutyLoot_Context_AddFavorite" xml:space="preserve">
+		<value>Add to Favorites</value>
+	</data>
+	<data name="DutyLoot_Context_Link" xml:space="preserve">
+		<value>Link</value>
+	</data>
+	<data name="DutyLoot_Context_RemoveFavorite" xml:space="preserve">
+		<value>Remove from Favorites</value>
+	</data>
+	<data name="DutyLoot_Context_SearchItem" xml:space="preserve">
+		<value>Search for Item</value>
+	</data>
+	<data name="DutyLoot_Context_SearchRecipes" xml:space="preserve">
+		<value>Search Recipes Using This Material</value>
+	</data>
+	<data name="DutyLoot_Context_TryOn" xml:space="preserve">
+		<value>Try On</value>
+	</data>
+	<data name="DutyLoot_Filter_All" xml:space="preserve">
+		<value>All Items</value>
+	</data>
+	<data name="DutyLoot_Filter_Equipment" xml:space="preserve">
+		<value>Equipment</value>
+	</data>
+	<data name="DutyLoot_Filter_Favorites" xml:space="preserve">
+		<value>Favorites</value>
+	</data>
+	<data name="DutyLoot_Filter_Misc" xml:space="preserve">
+		<value>Miscellaneous</value>
+	</data>
+	<data name="DutyLoot_LoadingMessage" xml:space="preserve">
+		<value>Loading loot data...</value>
+	</data>
+	<data name="DutyLoot_NoItemsMessage" xml:space="preserve">
+		<value>No loot data found for this duty.
+
+Data is provided by a third party and may be incomplete.</value>
+	</data>
+	<data name="DutyLoot_NoResultsMessage" xml:space="preserve">
+		<value>No results</value>
+	</data>
+	<data name="DutyLoot_Tooltip_InDutyButton" xml:space="preserve">
+		<value>[VanillaPlus] Open Duty Loot Preview Window</value>
+	</data>
+	<data name="DutyLoot_Tooltip_JournalButton" xml:space="preserve">
+		<value>View Loot that can be earned in this duty.</value>
+	</data>
+	<data name="FateEntry_LevelRangeFormat" xml:space="preserve">
+		<value>Lv. {0}-{1}</value>
+	</data>
+	<data name="FateEntry_LevelUnknown" xml:space="preserve">
+		<value>Lv. ???</value>
+	</data>
+	<data name="FateListWindow_Title" xml:space="preserve">
+		<value>Fate List</value>
+	</data>
+	<data name="HUDPresets_ButtonDelete" xml:space="preserve">
+		<value>Delete</value>
+	</data>
+	<data name="HUDPresets_ButtonLoad" xml:space="preserve">
+		<value>Load</value>
+	</data>
+	<data name="HUDPresets_ButtonLoadTooltip" xml:space="preserve">
+		<value>Load selected preset</value>
+	</data>
+	<data name="HUDPresets_ButtonOverwrite" xml:space="preserve">
+		<value>Overwrite</value>
+	</data>
+	<data name="HUDPresets_ButtonOverwriteTooltip" xml:space="preserve">
+		<value>Overwrite selected preset</value>
+	</data>
+	<data name="HUDPresets_ButtonSave" xml:space="preserve">
+		<value>Save</value>
+	</data>
+	<data name="HUDPresets_DefaultOption" xml:space="preserve">
+		<value>No Option Selected</value>
+	</data>
+	<data name="HUDPresets_DeleteTooltip" xml:space="preserve">
+		<value>Work in Progress
+Manually delete preset files for now</value>
+	</data>
+	<data name="HUDPresets_DropdownTooltip" xml:space="preserve">
+		<value>Select a HUD Layout Preset</value>
+	</data>
+	<data name="HUDPresets_Label" xml:space="preserve">
+		<value>[VanillaPlus] HUD Presets</value>
+	</data>
+	<data name="HUDPresets_PlaceholderNewPreset" xml:space="preserve">
+		<value>New Preset Name</value>
+	</data>
+	<data name="HUDPresets_RenameTitle" xml:space="preserve">
+		<value>HUD Preset Name</value>
+	</data>
+	<data name="HUDPresets_SaveTooltipDisabled" xml:space="preserve">
+		<value>Click save above before saving a new preset</value>
+	</data>
+	<data name="HUDPresets_SaveTooltipEnabled" xml:space="preserve">
+		<value>Save Current UI as a new preset</value>
+	</data>
+	<data name="Label_LocationDisplayInstructions" xml:space="preserve">
+		<value>Use the text box below to define how you want the text to be formatted.
+Use symbols {0} {1} {2} {3} {4} where you want the following values to be in the string
+
+{0} - Region (Ex. The Northern Empty)
+{1} - Territory (Ex. Old Sharlayan)
+{2} - Area (Ex. Archons Design)
+{3} - Sub-Area (Ex. Old Sharlayan Aetheryte Plaza)
+{4} - Housing Ward (Ex. Ward 14)</value>
+	</data>
+	<data name="LocationDisplay_DefaultEntryFormat" xml:space="preserve">
+		<value>{0}, {1}, {2}, {3}</value>
+	</data>
+	<data name="LocationDisplay_DefaultTooltipFormat" xml:space="preserve">
+		<value>{0}, {1}, {2}, {3}</value>
+	</data>
+	<data name="LocationDisplay_InfoBarEntryLabel" xml:space="preserve">
+		<value>Info Bar Entry</value>
+	</data>
+	<data name="LocationDisplay_InfoBarTooltipLabel" xml:space="preserve">
+		<value>Info Bar Tooltip</value>
+	</data>
+	<data name="LocationDisplay_ResetButton" xml:space="preserve">
+		<value>Reset to Default</value>
+	</data>
+	<data name="LocationDisplay_ShowInstanceNumber" xml:space="preserve">
+		<value>Show Instance Number</value>
+	</data>
+	<data name="LocationDisplay_ShowPreciseHousing" xml:space="preserve">
+		<value>Show Precise Housing Location</value>
+	</data>
+	<data name="LocationDisplay_ConfigTitle" xml:space="preserve">
+		<value>Location Display Config</value>
+	</data>
+	<data name="LocationDisplay_DtrEntryName" xml:space="preserve">
+		<value>VanillaPlus - LocationDisplay</value>
+	</data>
+	<data name="LocationDisplay_WardFormat" xml:space="preserve">
+		<value>Ward {0}</value>
+	</data>
+	<data name="LocationDisplay_SubdivisionLabel" xml:space="preserve">
+		<value>Subdivision</value>
+	</data>
+	<data name="LocationDisplay_ApartmentFormat" xml:space="preserve">
+		<value>Apartment {0}</value>
+	</data>
+	<data name="LocationDisplay_ApartmentLobby" xml:space="preserve">
+		<value>Lobby</value>
+	</data>
+	<data name="LocationDisplay_PlotFormat" xml:space="preserve">
+		<value>Plot {0}</value>
+	</data>
+	<data name="LocationDisplay_RoomFormat" xml:space="preserve">
+		<value>Room {0}</value>
+	</data>
+	<data name="MissingJobStone_Tooltip" xml:space="preserve">
+		<value>[VanillaPlus]: Click to disable lock</value>
+	</data>
+	<data name="MissingJobStone_TooltipWithCountdown" xml:space="preserve">
+		<value>[VanillaPlus]: Click to disable lock
+{0} Clicks remaining</value>
+	</data>
+	<data name="MissingJobStone_WarningText" xml:space="preserve">
+		<value>Missing Job Stone!</value>
+	</data>
+	<data name="ModificationDescription_ArmourySearchBar" xml:space="preserve">
+		<value>Adds a search bar to the armoury window.</value>
+	</data>
+	<data name="ModificationDescription_ClearFlag" xml:space="preserve">
+		<value>Allows you to right click the minimap to clear the currently set flag marker.</value>
+	</data>
+	<data name="ModificationDescription_ClearSelectedDuties" xml:space="preserve">
+		<value>When opening the Duty Finder, deselects any selected duties.</value>
+	</data>
+	<data name="ModificationDescription_ClearTextInputs" xml:space="preserve">
+		<value>Allows you to clear the text in a text input, by right clicking the text input.</value>
+	</data>
+	<data name="ModificationDescription_WondrousTailsProbabilities" xml:space="preserve">
+		<value>Displays current line probabilities and average reroll probabilities in the Wondrous Tails Book.</value>
+	</data>
+	<data name="ModificationDescription_WindowBackground" xml:space="preserve">
+		<value>Allows you to add a background to any native window.
+
+Examples: Cast Bar, Target Health Bar, Inventory Widget, Todo List.</value>
+	</data>
+	<data name="ModificationDescription_TargetCastBarCountdown" xml:space="preserve">
+		<value>Adds the time remaining for your targets current cast to the cast bar.</value>
+	</data>
+	<data name="ModificationDescription_SuppressDialogAdvance" xml:space="preserve">
+		<value>Prevents advancing a cutscene dialogue, unless you click on the dialogue box itself.</value>
+	</data>
+	<data name="ModificationDescription_StickyShopCategories" xml:space="preserve">
+		<value>Remembers the selected category and subcategories for certain vendors.</value>
+	</data>
+	<data name="ModificationDescription_SkipTeleportConfirm" xml:space="preserve">
+		<value>Skips the &apos;Teleport to [Location] for [amount] gil?&apos; popup when using the map to teleport.</value>
+	</data>
+	<data name="ModificationDescription_ShowAetherCurrents" xml:space="preserve">
+		<value>Shows all available aether currents on the map.</value>
+	</data>
+	<data name="ModificationDescription_SelectNextLootItem" xml:space="preserve">
+		<value>Automatically advance to the next loot item after clicking Need, Greed, or Pass.
+
+Note: this modification does not automatically roll on loot.</value>
+	</data>
+	<data name="ModificationDescription_SaddlebagSearchBar" xml:space="preserve">
+		<value>Adds a search bar to the saddlebag window.</value>
+	</data>
+	<data name="ModificationDescription_RetainerSearchBar" xml:space="preserve">
+		<value>Adds a search bar to the retainer window.</value>
+	</data>
+	<data name="ModificationDescription_ResourceBarPercentages" xml:space="preserve">
+		<value>Displays HP, MP, GP and CP bars as percentages instead of raw values.</value>
+	</data>
+	<data name="ModificationDescription_ResetInventoryTab" xml:space="preserve">
+		<value>Automatically resets the inventory to the first tab when opened.</value>
+	</data>
+	<data name="ModificationDescription_RecentlyLootedWindow" xml:space="preserve">
+		<value>Adds a window that shows a scrollable list of all items that you have looted this session.
+
+Can only show items looted after this feature is enabled.</value>
+	</data>
+	<data name="ModificationDescription_QuestListWindow" xml:space="preserve">
+		<value>Displays a list of all available quests for the currently occupied zone.</value>
+	</data>
+	<data name="ModificationDescription_OpenGlamourDresserToCurrentJob" xml:space="preserve">
+		<value>When opening the glamour dresser, the tab for your current job will be automatically selected.</value>
+	</data>
+	<data name="ModificationDescription_HideGuildhestObjectivePopup" xml:space="preserve">
+		<value>When starting a guildhest this modification will prevent the popup window that contains the instructions on how to do the Guildhest.
+
+This feature is not recommended if this is your first time doing Guildhests.</value>
+	</data>
+	<data name="ModificationDescription_HideMpBars" xml:space="preserve">
+		<value>Hides MP Bars in party list for jobs that don&apos;t use MP.</value>
+	</data>
+	<data name="ModificationDescription_HideUnwantedBanners" xml:space="preserve">
+		<value>Prevents large text banners from appearing and playing their sound effect.</value>
+	</data>
+	<data name="ModificationDescription_HUDCoordinates" xml:space="preserve">
+		<value>Display coordinate positions in HUD Layout nodes, allows you get get things exactly right.
+
+Displays coordinates for the center of the HUD element.</value>
+	</data>
+	<data name="ModificationDescription_InstancedWaymarks" xml:space="preserve">
+		<value>Enables the use of all saved Waymark Slots per duty, instead of sharing them across all duties, with the option to name each slot.</value>
+	</data>
+	<data name="ModificationDescription_InventorySearchBar" xml:space="preserve">
+		<value>Adds a search bar to the inventory window.</value>
+	</data>
+	<data name="ModificationDescription_ListInventory" xml:space="preserve">
+		<value>Adds a window that displays your inventory as a list, with toggleable filters.</value>
+	</data>
+	<data name="ModificationDescription_LocationDisplay" xml:space="preserve">
+		<value>Displays your current location in the server information bar.</value>
+	</data>
+	<data name="ModificationDescription_MacroLineNumbers" xml:space="preserve">
+		<value>Adds line numbers to the User Macros window.</value>
+	</data>
+	<data name="ModificationDescription_MacroTooltips" xml:space="preserve">
+		<value>Displays action tooltips when hovering over a macro with &quot;/macroicon&quot; set with an &apos;action&apos;.</value>
+	</data>
+	<data name="ModificationDescription_DebugCustomAddon" xml:space="preserve">
+		<value>A module for playing around and testing VanillaPlus features</value>
+	</data>
+	<data name="ModificationDescription_DebugGameModification" xml:space="preserve">
+		<value>A module for playing around and testing VanillaPlus features</value>
+	</data>
+	<data name="ModificationDescription_SampleGameModification" xml:space="preserve">
+		<value>SampleDescription</value>
+	</data>
+	<data name="ModificationDescription_BetterCursor" xml:space="preserve">
+		<value>Draws a ring around the cursor to make it easier to see.</value>
+	</data>
+	<data name="ModificationDescription_BetterInterruptableCastBars" xml:space="preserve">
+		<value>Makes enemy interruptable castbars much more noticeable.
+
+Additionally skills that can interrupt the cast are indicated on your hotbar.</value>
+	</data>
+	<data name="ModificationDescription_BetterQuestMapLink" xml:space="preserve">
+		<value>When clicking on quest links, open the actual map the quest is for instead of the generic world map.</value>
+	</data>
+	<data name="ModificationDescription_CastBarAetheryteNames" xml:space="preserve">
+		<value>Replaces the name of the action &apos;Teleport&apos; with the Aetheryte name of your destination.</value>
+	</data>
+	<data name="ModificationDescription_CurrencyOverlay" xml:space="preserve">
+		<value>Allows you to add additional currencies to your UI Overlay.
+
+Additionally allows you to set minimum and maximum values to trigger a warning.</value>
+	</data>
+	<data name="ModificationDescription_DraggableWindowDeadSpace" xml:space="preserve">
+		<value>Allows clicking and dragging on window dead space to move the window.</value>
+	</data>
+	<data name="ModificationDescription_DutyTimer" xml:space="preserve">
+		<value>When completing a duty, prints the time the duty took to chat.</value>
+	</data>
+	<data name="ModificationDescription_DutyLootPreview" xml:space="preserve">
+		<value>Adds a duty loot viewer to the duty window.</value>
+	</data>
+	<data name="ModificationDescription_EnhancedLootWindow" xml:space="preserve">
+		<value>Adds indicators to loot window items to indicate if you have unlocked that item before, or if the item is obtainable.</value>
+	</data>
+	<data name="ModificationDescription_FadeLootButton" xml:space="preserve">
+		<value>Fades the Loot button if you&apos;ve already rolled on everything available.</value>
+	</data>
+	<data name="ModificationDescription_FadeUnavailableActions" xml:space="preserve">
+		<value>Fades hotbar slots when the action is not able to be cast due to missing resources, out of range, or just on cooldown.
+
+Additionally fades actions that are not available because you are sync&apos;d down.</value>
+	</data>
+	<data name="ModificationDescription_FasterScroll" xml:space="preserve">
+		<value>Increases the speed of all scrollbars.</value>
+	</data>
+	<data name="ModificationDescription_FastMouseClick" xml:space="preserve">
+		<value>The game does not fire UI events for single mouse clicks whenever a double click is detected.
+
+This game modification fixes it by always triggering the normal mouse click in addition to the double click.</value>
+	</data>
+	<data name="ModificationDescription_FocusTargetLock" xml:space="preserve">
+		<value>When a duty recommences, restores your previous focus target.</value>
+	</data>
+	<data name="ModificationDescription_ForcedCutsceneSounds" xml:space="preserve">
+		<value>Automatically unmutes selected sound channels in cutscenes.</value>
+	</data>
+	<data name="ModificationDescription_HUDPresets" xml:space="preserve">
+		<value>Allows you to save and load an unlimited number of HUD Layouts.</value>
+	</data>
+	<data name="ModificationDescription_FateListWindow" xml:space="preserve">
+		<value>Displays a list of all fates that are currently active in the current zone.</value>
+	</data>
+	<data name="ModificationDescription_PetSizeContextMenu" xml:space="preserve">
+		<value>When right clicking on a pet, or a player with a pet, show a context menu entry for changing the pet size.</value>
+	</data>
+	<data name="ModificationDescription_MissingJobStoneLockout" xml:space="preserve">
+		<value>Prevents queuing for a duty while you are missing a jobstone.</value>
+	</data>
+	<data name="ModificationDescription_GearsetRedirect" xml:space="preserve">
+		<value>When equipping gearsets, set alternative sets to load depending on what zone you are in.</value>
+	</data>
+	<data name="ModificationDisplay_ArmourySearchBar" xml:space="preserve">
+		<value>Armoury Search Bar</value>
+	</data>
+	<data name="ModificationDisplay_ClearFlag" xml:space="preserve">
+		<value>Clear Flag</value>
+	</data>
+	<data name="ModificationDisplay_ClearSelectedDuties" xml:space="preserve">
+		<value>Clear Selected Duties</value>
+	</data>
+	<data name="ModificationDisplay_ClearTextInputs" xml:space="preserve">
+		<value>Clear Text Inputs</value>
+	</data>
+	<data name="ModificationDisplay_WondrousTailsProbabilities" xml:space="preserve">
+		<value>Wondrous Tails Probabilities</value>
+	</data>
+	<data name="WondrousTailsProbabilities_ErrorPlaceholder" xml:space="preserve">
+		<value>error </value>
+	</data>
+	<data name="WondrousTailsProbabilities_LineChancesLabel" xml:space="preserve">
+		<value>Line Chances: </value>
+	</data>
+	<data name="WondrousTailsProbabilities_ShuffleAverageLabel" xml:space="preserve">
+		<value>Shuffle Average: </value>
+	</data>
+	<data name="AddonConfig_KeybindWindowTitle" xml:space="preserve">
+		<value>Keybind Config Window</value>
+	</data>
+	<data name="AddonConfig_KeybindLabel" xml:space="preserve">
+		<value>Keybind</value>
+	</data>
+	<data name="Common_Disable" xml:space="preserve">
+		<value>Disable</value>
+	</data>
+	<data name="Common_Enable" xml:space="preserve">
+		<value>Enable</value>
+	</data>
+	<data name="AddonConfig_ChangeKeybind" xml:space="preserve">
+		<value>Change Keybind</value>
+	</data>
+	<data name="AddonConfig_WindowSizeLabel" xml:space="preserve">
+		<value>Window Size</value>
+	</data>
+	<data name="AddonConfig_WindowWidthLabel" xml:space="preserve">
+		<value>Width</value>
+	</data>
+	<data name="AddonConfig_WindowHeightLabel" xml:space="preserve">
+		<value>Height</value>
+	</data>
+	<data name="AddonConfig_ReloadHint" xml:space="preserve">
+		<value>Changes won&apos;t take effect until the window is reopened</value>
+	</data>
+	<data name="KeybindConfig_InputPrompt" xml:space="preserve">
+		<value>Input Desired Key Combo</value>
+	</data>
+	<data name="KeybindConfig_CurrentPrompt" xml:space="preserve">
+		<value>Press a Key Combo</value>
+	</data>
+	<data name="KeybindConfig_ConflictsLabel" xml:space="preserve">
+		<value>Keybind Conflict(s)</value>
+	</data>
+	<data name="KeybindConfig_NoConflicts" xml:space="preserve">
+		<value>No Conflicts Detected</value>
+	</data>
+	<data name="Common_Confirm" xml:space="preserve">
+		<value>Confirm</value>
+	</data>
+	<data name="Common_Cancel" xml:space="preserve">
+		<value>Cancel</value>
+	</data>
+	<data name="NodeList_ConfigWindowTitle" xml:space="preserve">
+		<value>{0} Configuration Window</value>
+	</data>
+	<data name="NodeList_OpenCommandHelp" xml:space="preserve">
+		<value>Opens the {0} Window</value>
+	</data>
+	<data name="SearchAddon_GearsetTitle" xml:space="preserve">
+		<value>Gearset Search</value>
+	</data>
+	<data name="SortOption_Alphabetical" xml:space="preserve">
+		<value>Alphabetical</value>
+	</data>
+	<data name="SortOption_Id" xml:space="preserve">
+		<value>Id</value>
+	</data>
+	<data name="SearchAddon_TerritoryTitle" xml:space="preserve">
+		<value>Zone Search</value>
+	</data>
+	<data name="ColorPicker_WindowTitle" xml:space="preserve">
+		<value>Color Picker</value>
+	</data>
+	<data name="NodeStyle_PositionLabel" xml:space="preserve">
+		<value>Position</value>
+	</data>
+	<data name="TextNodeConfig_TextColor" xml:space="preserve">
+		<value>Text Color</value>
+	</data>
+	<data name="TextNodeConfig_TextOutline" xml:space="preserve">
+		<value>Text Outline</value>
+	</data>
+	<data name="TextNodeConfig_FontSize" xml:space="preserve">
+		<value>Font Size</value>
+	</data>
+	<data name="TextNodeConfig_Font" xml:space="preserve">
+		<value>Font</value>
+	</data>
+	<data name="TextNodeConfig_Alignment" xml:space="preserve">
+		<value>Alignment</value>
+	</data>
+	<data name="IconWithCount_MillionsFormat" xml:space="preserve">
+		<value>{0}m</value>
+	</data>
+	<data name="IconWithCount_ThousandsFormat" xml:space="preserve">
+		<value>{0}k</value>
+	</data>
+	<data name="ModificationDisplay_WindowBackground" xml:space="preserve">
+		<value>Window Backgrounds</value>
+	</data>
+	<data name="ModificationDisplay_TargetCastBarCountdown" xml:space="preserve">
+		<value>Target Cast Bar Countdown</value>
+	</data>
+	<data name="ModificationDisplay_SuppressDialogAdvance" xml:space="preserve">
+		<value>Suppress Dialogue Advance</value>
+	</data>
+	<data name="ModificationDisplay_StickyShopCategories" xml:space="preserve">
+		<value>Sticky Shop Categories</value>
+	</data>
+	<data name="ModificationDisplay_SkipTeleportConfirm" xml:space="preserve">
+		<value>Skip Teleport Confirm</value>
+	</data>
+	<data name="ModificationDisplay_ShowAetherCurrents" xml:space="preserve">
+		<value>Show Aether Currents</value>
+	</data>
+	<data name="ModificationDisplay_SelectNextLootItem" xml:space="preserve">
+		<value>Automatically Select Next Loot Item</value>
+	</data>
+	<data name="ModificationDisplay_SaddlebagSearchBar" xml:space="preserve">
+		<value>Saddlebag Search Bar</value>
+	</data>
+	<data name="ModificationDisplay_RetainerSearchBar" xml:space="preserve">
+		<value>Retainer Search Bar</value>
+	</data>
+	<data name="ModificationDisplay_ResourceBarPercentages" xml:space="preserve">
+		<value>Show Resource Bars as Percentages</value>
+	</data>
+	<data name="ModificationDisplay_ResetInventoryTab" xml:space="preserve">
+		<value>Reset Inventory Tab</value>
+	</data>
+	<data name="ModificationDisplay_RecentlyLootedWindow" xml:space="preserve">
+		<value>Recently Looted Items Window</value>
+	</data>
+	<data name="ModificationDisplay_QuestListWindow" xml:space="preserve">
+		<value>Quest List Window</value>
+	</data>
+	<data name="ModificationDisplay_OpenGlamourDresserToCurrentJob" xml:space="preserve">
+		<value>Open Glamour Dresser to Current Job</value>
+	</data>
+	<data name="ModificationDisplay_HideGuildhestObjectivePopup" xml:space="preserve">
+		<value>Hide Guildhest Objective Popup</value>
+	</data>
+	<data name="ModificationDisplay_HideMpBars" xml:space="preserve">
+		<value>Hide MP Bars</value>
+	</data>
+	<data name="ModificationDisplay_HideUnwantedBanners" xml:space="preserve">
+		<value>Hide Unwanted Banners</value>
+	</data>
+	<data name="ModificationDisplay_HUDCoordinates" xml:space="preserve">
+		<value>HUD Coordinates</value>
+	</data>
+	<data name="ModificationDisplay_InstancedWaymarks" xml:space="preserve">
+		<value>Instanced Waymarks</value>
+	</data>
+	<data name="ModificationDisplay_InventorySearchBar" xml:space="preserve">
+		<value>Inventory Search Bar</value>
+	</data>
+	<data name="ModificationDisplay_ListInventory" xml:space="preserve">
+		<value>Inventory List Window</value>
+	</data>
+	<data name="ModificationDisplay_LocationDisplay" xml:space="preserve">
+		<value>Location Display</value>
+	</data>
+	<data name="ModificationDisplay_MacroLineNumbers" xml:space="preserve">
+		<value>Macro Line Numbers</value>
+	</data>
+	<data name="ModificationDisplay_MacroTooltips" xml:space="preserve">
+		<value>Macro Tooltips</value>
+	</data>
+	<data name="ModificationDisplay_DebugCustomAddon" xml:space="preserve">
+		<value>Debug CustomAddon</value>
+	</data>
+	<data name="ModificationDisplay_DebugGameModification" xml:space="preserve">
+		<value>Debug GameModification</value>
+	</data>
+	<data name="ModificationDisplay_SampleGameModification" xml:space="preserve">
+		<value>SampleDisplayName</value>
+	</data>
+	<data name="ModificationDisplay_BetterCursor" xml:space="preserve">
+		<value>Better Cursor</value>
+	</data>
+	<data name="ModificationDisplay_BetterInterruptableCastBars" xml:space="preserve">
+		<value>Better Interruptable Castbars</value>
+	</data>
+	<data name="ModificationDisplay_BetterQuestMapLink" xml:space="preserve">
+		<value>Better Quest Map Link</value>
+	</data>
+	<data name="ModificationDisplay_CastBarAetheryteNames" xml:space="preserve">
+		<value>Cast Bar Aetheryte Names</value>
+	</data>
+	<data name="ModificationDisplay_CurrencyOverlay" xml:space="preserve">
+		<value>Currency Overlay</value>
+	</data>
+	<data name="ModificationDisplay_DraggableWindowDeadSpace" xml:space="preserve">
+		<value>Draggable Window Dead Space</value>
+	</data>
+	<data name="ModificationDisplay_DutyTimer" xml:space="preserve">
+		<value>Duty Timer</value>
+	</data>
+	<data name="ModificationDisplay_DutyLootPreview" xml:space="preserve">
+		<value>Duty Loot Preview</value>
+	</data>
+	<data name="ModificationDisplay_EnhancedLootWindow" xml:space="preserve">
+		<value>Enhanced Loot Window</value>
+	</data>
+	<data name="ModificationDisplay_FadeLootButton" xml:space="preserve">
+		<value>Fade Loot Button</value>
+	</data>
+	<data name="ModificationDisplay_FadeUnavailableActions" xml:space="preserve">
+		<value>Fade Unavailable Actions</value>
+	</data>
+	<data name="ModificationDisplay_FasterScroll" xml:space="preserve">
+		<value>Faster Scrollbars</value>
+	</data>
+	<data name="ModificationDisplay_FastMouseClick" xml:space="preserve">
+		<value>Fast Mouse Click</value>
+	</data>
+	<data name="ModificationDisplay_FocusTargetLock" xml:space="preserve">
+		<value>Focus Target Lock</value>
+	</data>
+	<data name="ModificationDisplay_ForcedCutsceneSounds" xml:space="preserve">
+		<value>Forced Cutscene Sounds</value>
+	</data>
+	<data name="ModificationDisplay_HUDPresets" xml:space="preserve">
+		<value>HUD Presets</value>
+	</data>
+	<data name="ModificationDisplay_FateListWindow" xml:space="preserve">
+		<value>Fate List Window</value>
+	</data>
+	<data name="ModificationDisplay_PetSizeContextMenu" xml:space="preserve">
+		<value>Pet Size Context Menu</value>
+	</data>
+	<data name="PetSize_MenuTitle" xml:space="preserve">
+		<value>Pet Size</value>
+	</data>
+	<data name="PetSize_OptionLarge" xml:space="preserve">
+		<value>Large</value>
+	</data>
+	<data name="PetSize_OptionMedium" xml:space="preserve">
+		<value>Medium</value>
+	</data>
+	<data name="PetSize_OptionSmall" xml:space="preserve">
+		<value>Small</value>
+	</data>
+	<data name="ModificationDisplay_MissingJobStoneLockout" xml:space="preserve">
+		<value>Missing Job Stone Lockout</value>
+	</data>
+	<data name="ModificationDisplay_GearsetRedirect" xml:space="preserve">
+		<value>Gearset Redirect</value>
+	</data>
+	<data name="EnhancedLootWindow_CategorySettings" xml:space="preserve">
+		<value>Settings</value>
+	</data>
+	<data name="EnhancedLootWindow_ConfigTitle" xml:space="preserve">
+		<value>Enhanced Loot Window Config</value>
+	</data>
+	<data name="EnhancedLootWindow_LabelMarkAlreadyObtained" xml:space="preserve">
+		<value>Mark Already Unlocked Items</value>
+	</data>
+	<data name="EnhancedLootWindow_LabelMarkUnobtainable" xml:space="preserve">
+		<value>Mark Unobtainable Items</value>
+	</data>
+	<data name="FadeLootButton_CategoryStyleSettings" xml:space="preserve">
+		<value>Style Settings</value>
+	</data>
+	<data name="FadeLootButton_ConfigTitle" xml:space="preserve">
+		<value>Fade Loot Button Config</value>
+	</data>
+	<data name="FadeLootButton_LabelFadePercentage" xml:space="preserve">
+		<value>Fade Percentage</value>
+	</data>
+	<data name="FadeUnavailableActions_CategoryFeatureToggles" xml:space="preserve">
+		<value>Feature Toggles</value>
+	</data>
+	<data name="FadeUnavailableActions_CategoryStyleSettings" xml:space="preserve">
+		<value>Style Settings</value>
+	</data>
+	<data name="FadeUnavailableActions_ConfigTitle" xml:space="preserve">
+		<value>Fade Unavailable Actions Config</value>
+	</data>
+	<data name="FadeUnavailableActions_LabelApplyToFrame" xml:space="preserve">
+		<value>Apply Transparency to Frame</value>
+	</data>
+	<data name="FadeUnavailableActions_LabelApplyToSync" xml:space="preserve">
+		<value>Apply Only to Sync&apos;d Actions</value>
+	</data>
+	<data name="FadeUnavailableActions_LabelFadePercentage" xml:space="preserve">
+		<value>Fade Percentage</value>
+	</data>
+	<data name="FadeUnavailableActions_LabelReddenOutOfRange" xml:space="preserve">
+		<value>Redden Skills out of Range</value>
+	</data>
+	<data name="FadeUnavailableActions_LabelReddenPercentage" xml:space="preserve">
+		<value>Redden Percentage</value>
+	</data>
+	<data name="FasterScroll_CategorySettings" xml:space="preserve">
+		<value>Settings</value>
+	</data>
+	<data name="FasterScroll_ConfigTitle" xml:space="preserve">
+		<value>Faster Scrollbars Config</value>
+	</data>
+	<data name="FasterScroll_LabelSpeedMultiplier" xml:space="preserve">
+		<value>Speed Multiplier</value>
+	</data>
+	<data name="ForcedCutsceneSounds_CategoryGeneral" xml:space="preserve">
+		<value>General</value>
+	</data>
+	<data name="ForcedCutsceneSounds_CategorySpecial" xml:space="preserve">
+		<value>Special</value>
+	</data>
+	<data name="ForcedCutsceneSounds_CategoryToggles" xml:space="preserve">
+		<value>Toggles</value>
+	</data>
+	<data name="ForcedCutsceneSounds_ConfigTitle" xml:space="preserve">
+		<value>Forced Cutscene Sounds Config</value>
+	</data>
+	<data name="ForcedCutsceneSounds_DisableMsq" xml:space="preserve">
+		<value>Disable in MSQ Roulette</value>
+	</data>
+	<data name="ForcedCutsceneSounds_RestoreMuteState" xml:space="preserve">
+		<value>Restore Mute State After Cutscene</value>
+	</data>
+	<data name="ForcedCutsceneSounds_UnmuteBgm" xml:space="preserve">
+		<value>Unmute BGM</value>
+	</data>
+	<data name="ForcedCutsceneSounds_UnmuteEnv" xml:space="preserve">
+		<value>Unmute Ambient Sounds</value>
+	</data>
+	<data name="ForcedCutsceneSounds_UnmuteMaster" xml:space="preserve">
+		<value>Unmute Master Volume</value>
+	</data>
+	<data name="ForcedCutsceneSounds_UnmutePerform" xml:space="preserve">
+		<value>Unmute Performance</value>
+	</data>
+	<data name="ForcedCutsceneSounds_UnmuteSe" xml:space="preserve">
+		<value>Unmute Sound Effects</value>
+	</data>
+	<data name="ForcedCutsceneSounds_UnmuteSystem" xml:space="preserve">
+		<value>Unmute System Sounds</value>
+	</data>
+	<data name="ForcedCutsceneSounds_UnmuteVoice" xml:space="preserve">
+		<value>Unmute Voice</value>
+	</data>
+	<data name="GearsetRedirect_ConfigTitle" xml:space="preserve">
+		<value>Gearset Redirect Config</value>
+	</data>
+	<data name="GearsetRedirect_AddRedirectionTitle" xml:space="preserve">
+		<value>Add New Gearset Redirection</value>
+	</data>
+	<data name="GearsetRedirect_SortAlphabetical" xml:space="preserve">
+		<value>Alphabetical</value>
+	</data>
+	<data name="GearsetRedirect_SortId" xml:space="preserve">
+		<value>Id</value>
+	</data>
+	<data name="HideUnwantedBanners_ConfigTitle" xml:space="preserve">
+		<value>Hide Unwanted Banners Config</value>
+	</data>
+	<data name="InstancedWaymarks_RenameMenuLabel" xml:space="preserve">
+		<value>Rename</value>
+	</data>
+	<data name="InstancedWaymarks_RenameWindowTitle" xml:space="preserve">
+		<value>Waymark Rename Window</value>
+	</data>
+	<data name="DebugCustomAddon_Title" xml:space="preserve">
+		<value>Debug Addon Window</value>
+	</data>
+	<data name="ResourceBarPercentages_ApplyToPartyMembers" xml:space="preserve">
+		<value>Apply to Party Members</value>
+	</data>
+	<data name="ResourceBarPercentages_ApplyToPlayer" xml:space="preserve">
+		<value>Apply to Player</value>
+	</data>
+	<data name="ResourceBarPercentages_CategoryExtra" xml:space="preserve">
+		<value>Extra</value>
+	</data>
+	<data name="ResourceBarPercentages_CategoryParameterWidget" xml:space="preserve">
+		<value>Parameter Widget</value>
+	</data>
+	<data name="ResourceBarPercentages_CategoryPartyList" xml:space="preserve">
+		<value>Party List</value>
+	</data>
+	<data name="ResourceBarPercentages_CategoryPercentageFormat" xml:space="preserve">
+		<value>Percentage Format</value>
+	</data>
+	<data name="ResourceBarPercentages_CategoryPercentageSign" xml:space="preserve">
+		<value>Percentage Sign</value>
+	</data>
+	<data name="ResourceBarPercentages_ChangeCp" xml:space="preserve">
+		<value>Change CP</value>
+	</data>
+	<data name="ResourceBarPercentages_ChangeGp" xml:space="preserve">
+		<value>Change GP</value>
+	</data>
+	<data name="ResourceBarPercentages_ChangeHp" xml:space="preserve">
+		<value>Change HP</value>
+	</data>
+	<data name="ResourceBarPercentages_ChangeMp" xml:space="preserve">
+		<value>Change MP</value>
+	</data>
+	<data name="ResourceBarPercentages_ConfigTitle" xml:space="preserve">
+		<value>Resource Bar Percentages Config</value>
+	</data>
+	<data name="ResourceBarPercentages_DecimalPlaces" xml:space="preserve">
+		<value>Decimal Places</value>
+	</data>
+	<data name="ResourceBarPercentages_DeadOrAliveMode" xml:space="preserve">
+		<value>Dead or Alive Mode</value>
+	</data>
+	<data name="ResourceBarPercentages_ShowDecimalsBelowHundred" xml:space="preserve">
+		<value>Show Decimals Only While Below 100%</value>
+	</data>
+	<data name="ResourceBarPercentages_ShowOnParameterWidget" xml:space="preserve">
+		<value>Show on Parameter Widget</value>
+	</data>
+	<data name="ResourceBarPercentages_ShowOnPartyList" xml:space="preserve">
+		<value>Show on Party List</value>
+	</data>
+	<data name="ResourceBarPercentages_ShowPercentageSign" xml:space="preserve">
+		<value>Show Percentage Sign %</value>
+	</data>
+	<data name="ResourceBarPercentages_StatusAlive" xml:space="preserve">
+		<value>Alive</value>
+	</data>
+	<data name="ResourceBarPercentages_StatusDead" xml:space="preserve">
+		<value>Dead</value>
+	</data>
+	<data name="ListInventory_Title" xml:space="preserve">
+		<value>Inventory List</value>
+	</data>
+	<data name="ListInventory_FilterAlphabetically" xml:space="preserve">
+		<value>Alphabetically</value>
+	</data>
+	<data name="ListInventory_FilterQuantity" xml:space="preserve">
+		<value>Quantity</value>
+	</data>
+	<data name="ListInventory_FilterLevel" xml:space="preserve">
+		<value>Level</value>
+	</data>
+	<data name="ListInventory_FilterItemLevel" xml:space="preserve">
+		<value>Item Level</value>
+	</data>
+	<data name="ListInventory_FilterRarity" xml:space="preserve">
+		<value>Rarity</value>
+	</data>
+	<data name="ListInventory_FilterItemId" xml:space="preserve">
+		<value>Item Id</value>
+	</data>
+	<data name="ListInventory_FilterItemCategory" xml:space="preserve">
+		<value>Item Category</value>
+	</data>
+	<data name="RecentlyLootedWindow_Title" xml:space="preserve">
+		<value>Recently Looted Items</value>
+	</data>
+	<data name="QuestListWindow_Title" xml:space="preserve">
+		<value>Quest List</value>
+	</data>
+	<data name="QuestListWindow_FilterAlphabetically" xml:space="preserve">
+		<value>Alphabetically</value>
+	</data>
+	<data name="QuestListWindow_FilterDistance" xml:space="preserve">
+		<value>Distance</value>
+	</data>
+	<data name="QuestListWindow_FilterIssuerName" xml:space="preserve">
+		<value>Issuer Name</value>
+	</data>
+	<data name="QuestListWindow_FilterLevel" xml:space="preserve">
+		<value>Level</value>
+	</data>
+	<data name="QuestListWindow_FilterType" xml:space="preserve">
+		<value>Type</value>
+	</data>
+	<data name="ShowAetherCurrents_Tooltip" xml:space="preserve">
+		<value>Aether Current</value>
+	</data>
+	<data name="Title_DutyLootPreview" xml:space="preserve">
+		<value>Duty Loot Preview</value>
+	</data>
+	<data name="VersionLabelFormat" xml:space="preserve">
+		<value>Version {0}</value>
+	</data>
+</root>

--- a/VanillaPlus/Resources/Strings.zh.resx
+++ b/VanillaPlus/Resources/Strings.zh.resx
@@ -1,0 +1,1124 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+	<xsd:schema id="root" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+		<xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+		<xsd:element name="root" msdata:IsDataSet="true">
+			<xsd:complexType>
+				<xsd:choice maxOccurs="unbounded">
+					<xsd:element name="metadata">
+						<xsd:complexType>
+							<xsd:sequence>
+								<xsd:element name="value" type="xsd:string" minOccurs="0" />
+							</xsd:sequence>
+							<xsd:attribute name="name" use="required" type="xsd:string" />
+							<xsd:attribute name="type" type="xsd:string" />
+							<xsd:attribute name="mimetype" type="xsd:string" />
+							<xsd:attribute ref="xml:space" />
+						</xsd:complexType>
+					</xsd:element>
+					<xsd:element name="assembly">
+						<xsd:complexType>
+							<xsd:attribute name="alias" type="xsd:string" />
+							<xsd:attribute name="name" type="xsd:string" />
+						</xsd:complexType>
+					</xsd:element>
+					<xsd:element name="data">
+						<xsd:complexType>
+							<xsd:sequence>
+								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+								<xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+							</xsd:sequence>
+							<xsd:attribute name="name" type="xsd:string" use="required" />
+							<xsd:attribute name="type" type="xsd:string" />
+							<xsd:attribute name="mimetype" type="xsd:string" />
+							<xsd:attribute ref="xml:space" />
+						</xsd:complexType>
+					</xsd:element>
+					<xsd:element name="resheader">
+						<xsd:complexType>
+							<xsd:sequence>
+								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+							</xsd:sequence>
+							<xsd:attribute name="name" type="xsd:string" use="required" />
+						</xsd:complexType>
+					</xsd:element>
+				</xsd:choice>
+			</xsd:complexType>
+		</xsd:element>
+	</xsd:schema>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>2.0</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<data name="Button_SavePreset" xml:space="preserve">
+		<value>保存预设</value>
+	</data>
+	<data name="ChangelogBrowserTitle" xml:space="preserve">
+		<value>Vanilla Plus 更新日志浏览器</value>
+	</data>
+	<data name="ChangelogButtonLabel" xml:space="preserve">
+		<value>更新日志</value>
+	</data>
+	<data name="ChangelogTitleFormat" xml:space="preserve">
+		<value>{0}更新日志</value>
+	</data>
+	<data name="CommandHelpOpenBrowser" xml:space="preserve">
+		<value>打开改造功能浏览器</value>
+	</data>
+	<data name="ConfigCategory_Animations" xml:space="preserve">
+		<value>动画</value>
+	</data>
+	<data name="ConfigCategory_Colors" xml:space="preserve">
+		<value>颜色</value>
+	</data>
+	<data name="ConfigCategory_Icon" xml:space="preserve">
+		<value>图标</value>
+	</data>
+	<data name="ConfigLabel_ButtonColor" xml:space="preserve">
+		<value>按钮</value>
+	</data>
+	<data name="ConfigLabel_EnableAnimations" xml:space="preserve">
+		<value>启用动画</value>
+	</data>
+	<data name="ConfigLabel_Icon" xml:space="preserve">
+		<value>图标</value>
+	</data>
+	<data name="ConfigLabel_LaneColor" xml:space="preserve">
+		<value>通道</value>
+	</data>
+	<data name="BetterCursor_CategoryFunctions" xml:space="preserve">
+		<value>功能</value>
+	</data>
+	<data name="BetterCursor_CategoryIconSelection" xml:space="preserve">
+		<value>图标选择</value>
+	</data>
+	<data name="BetterCursor_CategoryStyle" xml:space="preserve">
+		<value>样式</value>
+	</data>
+	<data name="BetterCursor_CategoryVisibility" xml:space="preserve">
+		<value>可见性</value>
+	</data>
+	<data name="BetterCursor_ConfigTitle" xml:space="preserve">
+		<value>鼠标优化配置</value>
+	</data>
+	<data name="BetterCursor_EnableAnimation" xml:space="preserve">
+		<value>启用动画效果</value>
+	</data>
+	<data name="BetterCursor_HideOnCameraMove" xml:space="preserve">
+		<value>按住左键或右键拖动时隐藏</value>
+	</data>
+	<data name="BetterCursor_LabelColor" xml:space="preserve">
+		<value>颜色</value>
+	</data>
+	<data name="BetterCursor_LabelIcon" xml:space="preserve">
+		<value>图标</value>
+	</data>
+	<data name="BetterCursor_LabelSize" xml:space="preserve">
+		<value>大小</value>
+	</data>
+	<data name="BetterCursor_OnlyShowInCombat" xml:space="preserve">
+		<value>仅在战斗中显示</value>
+	</data>
+	<data name="BetterCursor_OnlyShowInDuties" xml:space="preserve">
+		<value>仅在任务中显示</value>
+	</data>
+	<data name="CurrencyOverlay_ConfigTitle" xml:space="preserve">
+		<value>货币叠加层配置</value>
+	</data>
+	<data name="CurrencyOverlay_ItemSearchTitle" xml:space="preserve">
+		<value>物品搜索</value>
+	</data>
+	<data name="CurrencyOverlay_SortOptionAlphabetical" xml:space="preserve">
+		<value>按字母顺序</value>
+	</data>
+	<data name="CurrencyOverlay_SortOptionId" xml:space="preserve">
+		<value>按ID</value>
+	</data>
+	<data name="WindowBackground_ConfigTitle" xml:space="preserve">
+		<value>窗口背景配置</value>
+	</data>
+	<data name="WindowBackground_SearchTitle" xml:space="preserve">
+		<value>窗口搜索</value>
+	</data>
+	<data name="WindowBackground_SortOptionAlphabetical" xml:space="preserve">
+		<value>按字母顺序</value>
+	</data>
+	<data name="WindowBackground_SortOptionVisibility" xml:space="preserve">
+		<value>按可见性</value>
+	</data>
+	<data name="WindowBackground_ColorPickerTitle" xml:space="preserve">
+		<value>窗口背景取色器</value>
+	</data>
+	<data name="WindowBackground_CategoryBackgroundColor" xml:space="preserve">
+		<value>背景颜色</value>
+	</data>
+	<data name="WindowBackground_ColorLabel" xml:space="preserve">
+		<value>颜色</value>
+	</data>
+	<data name="WindowBackground_CategoryPaddingSize" xml:space="preserve">
+		<value>内边距大小</value>
+	</data>
+	<data name="TargetCastBarCountdown_CategoryFocusStyle" xml:space="preserve">
+		<value>焦点目标咏唱条样式</value>
+	</data>
+	<data name="TargetCastBarCountdown_CategoryNameplateStyle" xml:space="preserve">
+		<value>名牌咏唱条样式</value>
+	</data>
+	<data name="TargetCastBarCountdown_CategoryPrimaryAltStyle" xml:space="preserve">
+		<value>目标咏唱条样式（分离）</value>
+	</data>
+	<data name="TargetCastBarCountdown_CategoryPrimaryStyle" xml:space="preserve">
+		<value>目标咏唱条样式（合并）</value>
+	</data>
+	<data name="TargetCastBarCountdown_CategoryToggles" xml:space="preserve">
+		<value>开关</value>
+	</data>
+	<data name="TargetCastBarCountdown_CheckboxFocus" xml:space="preserve">
+		<value>在焦点目标咏唱条上显示</value>
+	</data>
+	<data name="TargetCastBarCountdown_CheckboxNameplate" xml:space="preserve">
+		<value>在名牌目标咏唱条上显示</value>
+	</data>
+	<data name="TargetCastBarCountdown_CheckboxPrimary" xml:space="preserve">
+		<value>在主目标咏唱条上显示</value>
+	</data>
+	<data name="TargetCastBarCountdown_ConfigTitle" xml:space="preserve">
+		<value>目标咏唱条倒计时配置</value>
+	</data>
+	<data name="SuppressDialogAdvance_ApplyOnlyInCutscenes" xml:space="preserve">
+		<value>仅在过场动画中应用</value>
+	</data>
+	<data name="SuppressDialogAdvance_CategoryGeneral" xml:space="preserve">
+		<value>常规</value>
+	</data>
+	<data name="SuppressDialogAdvance_ConfigTitle" xml:space="preserve">
+		<value>对话推进抑制配置</value>
+	</data>
+	<data name="ClearSelectedDuties_ConfigTitle" xml:space="preserve">
+		<value>清除已选任务配置</value>
+	</data>
+	<data name="ClearSelectedDuties_DisableWhenUnrestricted" xml:space="preserve">
+		<value>在无视人数限制时禁用</value>
+	</data>
+	<data name="ClearSelectedDuties_SettingsCategory" xml:space="preserve">
+		<value>设置</value>
+	</data>
+	<data name="Label_ModAuthorBy" xml:space="preserve">
+		<value>作者：{0}</value>
+	</data>
+	<data name="ModificationBrowserTitle" xml:space="preserve">
+		<value>Vanilla Plus 浏览器</value>
+	</data>
+	<data name="ModificationDescription_MiniCactpotHelper" xml:space="preserve">
+		<value>提示下一格仙人微彩应揭示的位置。</value>
+	</data>
+	<data name="ModificationDescription_PartyFinderPresets" xml:space="preserve">
+		<value>允许在组队招募窗口保存并使用预设。</value>
+	</data>
+	<data name="ModificationDisplay_MiniCactpotHelper" xml:space="preserve">
+		<value>仙人微彩助手</value>
+	</data>
+	<data name="ModificationDisplay_PartyFinderPresets" xml:space="preserve">
+		<value>组队招募预设</value>
+	</data>
+	<data name="Preset_DefaultOption" xml:space="preserve">
+		<value>尚未保存预设</value>
+	</data>
+	<data name="Preset_DontUseOption" xml:space="preserve">
+		<value>不使用预设</value>
+	</data>
+	<data name="SearchPlaceholder" xml:space="preserve">
+		<value>搜索...</value>
+	</data>
+	<data name="SelectionPrompt" xml:space="preserve">
+		<value>请在左侧选择一个选项</value>
+	</data>
+	<data name="Title_MiniCactpotConfig" xml:space="preserve">
+		<value>仙人微彩助手配置</value>
+	</data>
+	<data name="Title_PartyFinderPreset" xml:space="preserve">
+		<value>组队招募预设</value>
+	</data>
+	<data name="Title_PresetConfigManager" xml:space="preserve">
+		<value>预设配置管理器</value>
+	</data>
+	<data name="Tooltip_ConfigEzMiniCactpot" xml:space="preserve">
+		<value>配置 EzMiniCactpot 插件</value>
+	</data>
+	<data name="Tooltip_ExperimentalFeature" xml:space="preserve">
+		<value>注意：此功能仍在实验阶段。
+可能包含错误或导致游戏崩溃。</value>
+	</data>
+	<data name="Tooltip_ModificationFailedToLoad" xml:space="preserve">
+		<value>加载失败，此模块已被禁用</value>
+	</data>
+	<data name="Tooltip_NoPresets" xml:space="preserve">
+		<value>[VanillaPlus]: 尚未保存预设</value>
+	</data>
+	<data name="Tooltip_OpenConfiguration" xml:space="preserve">
+		<value>打开设置窗口</value>
+	</data>
+	<data name="Tooltip_ReverseSortDirection" xml:space="preserve">
+		<value>反向排序</value>
+	</data>
+	<data name="Tooltip_RetryCompatibility" xml:space="preserve">
+		<value>重新尝试兼容性检查</value>
+	</data>
+	<data name="Tooltip_SavePreset" xml:space="preserve">
+		<value>[VanillaPlus]: 将当前设置保存为预设</value>
+	</data>
+	<data name="Tooltip_SearchRegexSupport" xml:space="preserve">
+		<value>[VanillaPlus]: 支持正则搜索
+输入以 &apos;$&apos; 开头即可按描述搜索</value>
+	</data>
+	<data name="Tooltip_SelectPreset" xml:space="preserve">
+		<value>[VanillaPlus]: 选择预设</value>
+	</data>
+	<data name="DutyTimer_CompletedMessage" xml:space="preserve">
+		<value>任务完成耗时：{0}</value>
+	</data>
+	<data name="DutyLoot_Context_AddFavorite" xml:space="preserve">
+		<value>加入收藏</value>
+	</data>
+	<data name="DutyLoot_Context_Link" xml:space="preserve">
+		<value>链接</value>
+	</data>
+	<data name="DutyLoot_Context_RemoveFavorite" xml:space="preserve">
+		<value>从收藏中移除</value>
+	</data>
+	<data name="DutyLoot_Context_SearchItem" xml:space="preserve">
+		<value>搜索该物品</value>
+	</data>
+	<data name="DutyLoot_Context_SearchRecipes" xml:space="preserve">
+		<value>搜索使用该材料的配方</value>
+	</data>
+	<data name="DutyLoot_Context_TryOn" xml:space="preserve">
+		<value>试穿</value>
+	</data>
+	<data name="DutyLoot_Filter_All" xml:space="preserve">
+		<value>全部物品</value>
+	</data>
+	<data name="DutyLoot_Filter_Equipment" xml:space="preserve">
+		<value>装备</value>
+	</data>
+	<data name="DutyLoot_Filter_Favorites" xml:space="preserve">
+		<value>收藏</value>
+	</data>
+	<data name="DutyLoot_Filter_Misc" xml:space="preserve">
+		<value>杂项</value>
+	</data>
+	<data name="DutyLoot_LoadingMessage" xml:space="preserve">
+		<value>正在载入战利品数据...</value>
+	</data>
+	<data name="DutyLoot_NoItemsMessage" xml:space="preserve">
+		<value>未找到此任务的战利品数据。
+
+数据由第三方提供，可能不完整。</value>
+	</data>
+	<data name="DutyLoot_NoResultsMessage" xml:space="preserve">
+		<value>没有结果</value>
+	</data>
+	<data name="DutyLoot_Tooltip_InDutyButton" xml:space="preserve">
+		<value>[VanillaPlus] 打开任务战利品预览窗口</value>
+	</data>
+	<data name="DutyLoot_Tooltip_JournalButton" xml:space="preserve">
+		<value>查看该任务可获得的战利品。</value>
+	</data>
+	<data name="FateEntry_LevelRangeFormat" xml:space="preserve">
+		<value>等级 {0}-{1}</value>
+	</data>
+	<data name="FateEntry_LevelUnknown" xml:space="preserve">
+		<value>等级 ???</value>
+	</data>
+	<data name="FateListWindow_Title" xml:space="preserve">
+		<value>Fate列表</value>
+	</data>
+	<data name="HUDPresets_ButtonDelete" xml:space="preserve">
+		<value>删除</value>
+	</data>
+	<data name="HUDPresets_ButtonLoad" xml:space="preserve">
+		<value>载入</value>
+	</data>
+	<data name="HUDPresets_ButtonLoadTooltip" xml:space="preserve">
+		<value>载入所选预设</value>
+	</data>
+	<data name="HUDPresets_ButtonOverwrite" xml:space="preserve">
+		<value>覆盖</value>
+	</data>
+	<data name="HUDPresets_ButtonOverwriteTooltip" xml:space="preserve">
+		<value>覆盖所选预设</value>
+	</data>
+	<data name="HUDPresets_ButtonSave" xml:space="preserve">
+		<value>保存</value>
+	</data>
+	<data name="HUDPresets_DefaultOption" xml:space="preserve">
+		<value>未选择选项</value>
+	</data>
+	<data name="HUDPresets_DeleteTooltip" xml:space="preserve">
+		<value>功能开发中
+请暂时手动删除预设文件</value>
+	</data>
+	<data name="HUDPresets_DropdownTooltip" xml:space="preserve">
+		<value>选择 HUD 布局预设</value>
+	</data>
+	<data name="HUDPresets_Label" xml:space="preserve">
+		<value>[VanillaPlus] HUD 预设</value>
+	</data>
+	<data name="HUDPresets_PlaceholderNewPreset" xml:space="preserve">
+		<value>新预设名称</value>
+	</data>
+	<data name="HUDPresets_RenameTitle" xml:space="preserve">
+		<value>HUD 预设名称</value>
+	</data>
+	<data name="HUDPresets_SaveTooltipDisabled" xml:space="preserve">
+		<value>请先点击上方的保存，再保存新预设</value>
+	</data>
+	<data name="HUDPresets_SaveTooltipEnabled" xml:space="preserve">
+		<value>将当前界面保存为新预设</value>
+	</data>
+	<data name="Label_LocationDisplayInstructions" xml:space="preserve">
+		<value>请在下方文本框中定义所需的文本格式。
+在希望插入以下数值的位置使用 {0} {1} {2} {3} {4}
+
+{0} - 大区（示例：主世界区域）
+{1} - 区域（示例：城市或野外）
+{2} - 地区（示例：更细分的地点）
+{3} - 子区域（示例：地标或广场）
+{4} - 房区（示例：第14区）</value>
+	</data>
+	<data name="LocationDisplay_DefaultEntryFormat" xml:space="preserve">
+		<value>{0}, {1}, {2}, {3}</value>
+	</data>
+	<data name="LocationDisplay_DefaultTooltipFormat" xml:space="preserve">
+		<value>{0}, {1}, {2}, {3}</value>
+	</data>
+	<data name="LocationDisplay_InfoBarEntryLabel" xml:space="preserve">
+		<value>信息栏条目</value>
+	</data>
+	<data name="LocationDisplay_InfoBarTooltipLabel" xml:space="preserve">
+		<value>信息栏提示</value>
+	</data>
+	<data name="LocationDisplay_ResetButton" xml:space="preserve">
+		<value>重置为默认</value>
+	</data>
+	<data name="LocationDisplay_ShowInstanceNumber" xml:space="preserve">
+		<value>显示分区编号</value>
+	</data>
+	<data name="LocationDisplay_ShowPreciseHousing" xml:space="preserve">
+		<value>显示精确房屋位置</value>
+	</data>
+	<data name="LocationDisplay_ConfigTitle" xml:space="preserve">
+		<value>位置显示配置</value>
+	</data>
+	<data name="LocationDisplay_DtrEntryName" xml:space="preserve">
+		<value>VanillaPlus - LocationDisplay</value>
+	</data>
+	<data name="LocationDisplay_WardFormat" xml:space="preserve">
+		<value>{0}区</value>
+	</data>
+	<data name="LocationDisplay_SubdivisionLabel" xml:space="preserve">
+		<value>扩建区</value>
+	</data>
+	<data name="LocationDisplay_ApartmentFormat" xml:space="preserve">
+		<value>公寓{0}</value>
+	</data>
+	<data name="LocationDisplay_ApartmentLobby" xml:space="preserve">
+		<value>大堂</value>
+	</data>
+	<data name="LocationDisplay_PlotFormat" xml:space="preserve">
+		<value>{0}号</value>
+	</data>
+	<data name="LocationDisplay_RoomFormat" xml:space="preserve">
+		<value>房间{0}</value>
+	</data>
+	<data name="MissingJobStone_Tooltip" xml:space="preserve">
+		<value>[VanillaPlus]: 点击以解除锁定</value>
+	</data>
+	<data name="MissingJobStone_TooltipWithCountdown" xml:space="preserve">
+		<value>[VanillaPlus]: 点击以解除锁定
+剩余 {0} 次点击</value>
+	</data>
+	<data name="MissingJobStone_WarningText" xml:space="preserve">
+		<value>缺少灵魂水晶！</value>
+	</data>
+	<data name="ModificationDescription_ArmourySearchBar" xml:space="preserve">
+		<value>在军需品箱窗口添加搜索栏。</value>
+	</data>
+	<data name="ModificationDescription_ClearFlag" xml:space="preserve">
+		<value>允许右键点击小地图以清除当前的旗标。</value>
+	</data>
+	<data name="ModificationDescription_ClearSelectedDuties" xml:space="preserve">
+		<value>打开任务搜寻器时，自动取消所有已选任务。</value>
+	</data>
+	<data name="ModificationDescription_ClearTextInputs" xml:space="preserve">
+		<value>允许右键点击文本输入框以清除内容。</value>
+	</data>
+	<data name="ModificationDescription_WondrousTailsProbabilities" xml:space="preserve">
+		<value>在奇谈书中显示当前连线概率以及平均重掷概率。</value>
+	</data>
+	<data name="ModificationDescription_WindowBackground" xml:space="preserve">
+		<value>允许为任意系统窗口添加背景。
+
+示例：咏唱条、目标血条、背包组件、待办列表。</value>
+	</data>
+	<data name="ModificationDescription_TargetCastBarCountdown" xml:space="preserve">
+		<value>在目标当前的咏唱条上显示剩余时间。</value>
+	</data>
+	<data name="ModificationDescription_SuppressDialogAdvance" xml:space="preserve">
+		<value>只有点击对话框本体时才允许推进过场对话。</value>
+	</data>
+	<data name="ModificationDescription_StickyShopCategories" xml:space="preserve">
+		<value>记住部分商人的类别与子类别选择。</value>
+	</data>
+	<data name="ModificationDescription_SkipTeleportConfirm" xml:space="preserve">
+		<value>使用地图传送时，跳过 &quot;传送至[地点]需要支付[金额]金币，是否继续？&quot; 的确认弹窗。</value>
+	</data>
+	<data name="ModificationDescription_ShowAetherCurrents" xml:space="preserve">
+		<value>在地图上显示所有可获取的风脉泉。</value>
+	</data>
+	<data name="ModificationDescription_SelectNextLootItem" xml:space="preserve">
+		<value>点击需求/贪婪/放弃后自动切换到下一条战利品。
+
+注意：此功能不会自动掷点。</value>
+	</data>
+	<data name="ModificationDescription_SaddlebagSearchBar" xml:space="preserve">
+		<value>在陆行鸟鞍囊窗口添加搜索栏。</value>
+	</data>
+	<data name="ModificationDescription_RetainerSearchBar" xml:space="preserve">
+		<value>在雇员窗口添加搜索栏。</value>
+	</data>
+	<data name="ModificationDescription_ResourceBarPercentages" xml:space="preserve">
+		<value>将 HP、MP、GP 与 CP 条显示为百分比。</value>
+	</data>
+	<data name="ModificationDescription_ResetInventoryTab" xml:space="preserve">
+		<value>打开物品栏时自动切换到第一页签。</value>
+	</data>
+	<data name="ModificationDescription_RecentlyLootedWindow" xml:space="preserve">
+		<value>添加窗口显示本次登录期间获得的所有物品。
+
+只有启用后获得的战利品才会记录。</value>
+	</data>
+	<data name="ModificationDescription_QuestListWindow" xml:space="preserve">
+		<value>显示当前区域所有可接任务的列表。</value>
+	</data>
+	<data name="ModificationDescription_OpenGlamourDresserToCurrentJob" xml:space="preserve">
+		<value>打开幻化柜时自动选择当前职业的分页。</value>
+	</data>
+	<data name="ModificationDescription_HideGuildhestObjectivePopup" xml:space="preserve">
+		<value>开始行会令时阻止显示流程说明弹窗。
+
+若是第一次进行行会令，建议关闭此功能。</value>
+	</data>
+	<data name="ModificationDescription_HideMpBars" xml:space="preserve">
+		<value>为不使用 MP 的职业隐藏队伍列表中的 MP 条。</value>
+	</data>
+	<data name="ModificationDescription_HideUnwantedBanners" xml:space="preserve">
+		<value>阻止大型文字横幅及其音效。</value>
+	</data>
+	<data name="ModificationDescription_HUDCoordinates" xml:space="preserve">
+		<value>在 HUD 布局节点上显示坐标，便于精确调整。
+
+坐标以 HUD 元素中心为准。</value>
+	</data>
+	<data name="ModificationDescription_InstancedWaymarks" xml:space="preserve">
+		<value>为每个任务启用独立的标点存档，并可为各槽位命名。</value>
+	</data>
+	<data name="ModificationDescription_InventorySearchBar" xml:space="preserve">
+		<value>在物品栏窗口添加搜索栏。</value>
+	</data>
+	<data name="ModificationDescription_ListInventory" xml:space="preserve">
+		<value>添加一个以列表方式显示物品栏并可切换筛选的窗口。</value>
+	</data>
+	<data name="ModificationDescription_LocationDisplay" xml:space="preserve">
+		<value>在服务器信息栏中显示当前位置。</value>
+	</data>
+	<data name="ModificationDescription_MacroLineNumbers" xml:space="preserve">
+		<value>在用户宏窗口中显示行号。</value>
+	</data>
+	<data name="ModificationDescription_MacroTooltips" xml:space="preserve">
+		<value>宏中使用 &quot;/macroicon&quot; 并引用动作时，鼠标悬停显示该动作的提示。</value>
+	</data>
+	<data name="ModificationDescription_DebugCustomAddon" xml:space="preserve">
+		<value>用于试验与测试 VanillaPlus 功能的模块</value>
+	</data>
+	<data name="ModificationDescription_DebugGameModification" xml:space="preserve">
+		<value>用于试验与测试 VanillaPlus 功能的模块</value>
+	</data>
+	<data name="ModificationDescription_SampleGameModification" xml:space="preserve">
+		<value>示例说明</value>
+	</data>
+	<data name="ModificationDescription_BetterCursor" xml:space="preserve">
+		<value>在光标周围绘制一个环形指示，方便辨识位置。</value>
+	</data>
+	<data name="ModificationDescription_BetterInterruptableCastBars" xml:space="preserve">
+		<value>让敌方可打断的咏唱条更加显眼。
+
+同时在热键栏上标出可打断该技能的动作。</value>
+	</data>
+	<data name="ModificationDescription_BetterQuestMapLink" xml:space="preserve">
+		<value>点击任务链接时，直接打开该任务所在的地图。</value>
+	</data>
+	<data name="ModificationDescription_CastBarAetheryteNames" xml:space="preserve">
+		<value>将 &quot;传送&quot; 动作的名称替换为目的地以太水晶名称。</value>
+	</data>
+	<data name="ModificationDescription_CurrencyOverlay" xml:space="preserve">
+		<value>允许在 UI 叠加层中显示更多货币。
+
+还能设定提醒所需的最小与最大值。</value>
+	</data>
+	<data name="ModificationDescription_DraggableWindowDeadSpace" xml:space="preserve">
+		<value>允许拖动窗口空白区域以移动窗口。</value>
+	</data>
+	<data name="ModificationDescription_DutyTimer" xml:space="preserve">
+		<value>完成任务时，将耗时发送到聊天框。</value>
+	</data>
+	<data name="ModificationDescription_DutyLootPreview" xml:space="preserve">
+		<value>在任务窗口中加入战利品查看器。</value>
+	</data>
+	<data name="ModificationDescription_EnhancedLootWindow" xml:space="preserve">
+		<value>在战利品窗口显示该物品是否已解锁或可获得。</value>
+	</data>
+	<data name="ModificationDescription_FadeLootButton" xml:space="preserve">
+		<value>当全部战利品都已掷点时，让战利品按钮变淡。</value>
+	</data>
+	<data name="ModificationDescription_FadeUnavailableActions" xml:space="preserve">
+		<value>当动作因资源不足、距离过远或冷却中无法使用时，让热键槽渐隐。
+
+同步降级导致不可用的动作也会变淡。</value>
+	</data>
+	<data name="ModificationDescription_FasterScroll" xml:space="preserve">
+		<value>提升所有滚动条的速度。</value>
+	</data>
+	<data name="ModificationDescription_FastMouseClick" xml:space="preserve">
+		<value>游戏检测到双击时不会触发单击事件。
+
+此功能会在触发双击时同时补发一次单击事件。</value>
+	</data>
+	<data name="ModificationDescription_FocusTargetLock" xml:space="preserve">
+		<value>职责重新开始时，恢复之前的焦点目标。</value>
+	</data>
+	<data name="ModificationDescription_ForcedCutsceneSounds" xml:space="preserve">
+		<value>在过场动画中自动取消所选声音频道的静音。</value>
+	</data>
+	<data name="ModificationDescription_HUDPresets" xml:space="preserve">
+		<value>允许保存并加载无限数量的 HUD 布局。</value>
+	</data>
+	<data name="ModificationDescription_FateListWindow" xml:space="preserve">
+		<value>显示当前区域内所有正在进行的命运之战。</value>
+	</data>
+	<data name="ModificationDescription_PetSizeContextMenu" xml:space="preserve">
+		<value>右键点击召唤兽或拥有召唤兽的玩家时，可在菜单中调整召唤兽大小。</value>
+	</data>
+	<data name="ModificationDescription_MissingJobStoneLockout" xml:space="preserve">
+		<value>缺少灵魂水晶时阻止排队进入任务。</value>
+	</data>
+	<data name="ModificationDescription_GearsetRedirect" xml:space="preserve">
+		<value>根据所在区域，为装备套装指定替代套装。</value>
+	</data>
+	<data name="ModificationDisplay_ArmourySearchBar" xml:space="preserve">
+		<value>军需品箱搜索栏</value>
+	</data>
+	<data name="ModificationDisplay_ClearFlag" xml:space="preserve">
+		<value>清除旗标</value>
+	</data>
+	<data name="ModificationDisplay_ClearSelectedDuties" xml:space="preserve">
+		<value>清除已选任务</value>
+	</data>
+	<data name="ModificationDisplay_ClearTextInputs" xml:space="preserve">
+		<value>清空文本输入</value>
+	</data>
+	<data name="ModificationDisplay_WondrousTailsProbabilities" xml:space="preserve">
+		<value>奇谈书概率</value>
+	</data>
+	<data name="WondrousTailsProbabilities_ErrorPlaceholder" xml:space="preserve">
+		<value>错误 </value>
+	</data>
+	<data name="WondrousTailsProbabilities_LineChancesLabel" xml:space="preserve">
+		<value>连线概率： </value>
+	</data>
+	<data name="WondrousTailsProbabilities_ShuffleAverageLabel" xml:space="preserve">
+		<value>重抽平均： </value>
+	</data>
+	<data name="AddonConfig_KeybindWindowTitle" xml:space="preserve">
+		<value>按键设置窗口</value>
+	</data>
+	<data name="AddonConfig_KeybindLabel" xml:space="preserve">
+		<value>按键绑定</value>
+	</data>
+	<data name="Common_Disable" xml:space="preserve">
+		<value>禁用</value>
+	</data>
+	<data name="Common_Enable" xml:space="preserve">
+		<value>启用</value>
+	</data>
+	<data name="AddonConfig_ChangeKeybind" xml:space="preserve">
+		<value>更改按键绑定</value>
+	</data>
+	<data name="AddonConfig_WindowSizeLabel" xml:space="preserve">
+		<value>窗口大小</value>
+	</data>
+	<data name="AddonConfig_WindowWidthLabel" xml:space="preserve">
+		<value>宽度</value>
+	</data>
+	<data name="AddonConfig_WindowHeightLabel" xml:space="preserve">
+		<value>高度</value>
+	</data>
+	<data name="AddonConfig_ReloadHint" xml:space="preserve">
+		<value>重新打开窗口后更改才会生效</value>
+	</data>
+	<data name="KeybindConfig_InputPrompt" xml:space="preserve">
+		<value>输入想要的按键组合</value>
+	</data>
+	<data name="KeybindConfig_CurrentPrompt" xml:space="preserve">
+		<value>请按下按键组合</value>
+	</data>
+	<data name="KeybindConfig_ConflictsLabel" xml:space="preserve">
+		<value>按键冲突</value>
+	</data>
+	<data name="KeybindConfig_NoConflicts" xml:space="preserve">
+		<value>未检测到冲突</value>
+	</data>
+	<data name="Common_Confirm" xml:space="preserve">
+		<value>确定</value>
+	</data>
+	<data name="Common_Cancel" xml:space="preserve">
+		<value>取消</value>
+	</data>
+	<data name="NodeList_ConfigWindowTitle" xml:space="preserve">
+		<value>{0}配置窗口</value>
+	</data>
+	<data name="NodeList_OpenCommandHelp" xml:space="preserve">
+		<value>打开[{0}]窗口</value>
+	</data>
+	<data name="SearchAddon_GearsetTitle" xml:space="preserve">
+		<value>套装搜索</value>
+	</data>
+	<data name="SortOption_Alphabetical" xml:space="preserve">
+		<value>按字母顺序</value>
+	</data>
+	<data name="SortOption_Id" xml:space="preserve">
+		<value>按ID</value>
+	</data>
+	<data name="SearchAddon_TerritoryTitle" xml:space="preserve">
+		<value>区域搜索</value>
+	</data>
+	<data name="ColorPicker_WindowTitle" xml:space="preserve">
+		<value>颜色选择器</value>
+	</data>
+	<data name="NodeStyle_PositionLabel" xml:space="preserve">
+		<value>位置</value>
+	</data>
+	<data name="TextNodeConfig_TextColor" xml:space="preserve">
+		<value>文字颜色</value>
+	</data>
+	<data name="TextNodeConfig_TextOutline" xml:space="preserve">
+		<value>文字描边</value>
+	</data>
+	<data name="TextNodeConfig_FontSize" xml:space="preserve">
+		<value>字体大小</value>
+	</data>
+	<data name="TextNodeConfig_Font" xml:space="preserve">
+		<value>字体</value>
+	</data>
+	<data name="TextNodeConfig_Alignment" xml:space="preserve">
+		<value>对齐方式</value>
+	</data>
+	<data name="IconWithCount_MillionsFormat" xml:space="preserve">
+		<value>{0}m</value>
+	</data>
+	<data name="IconWithCount_ThousandsFormat" xml:space="preserve">
+		<value>{0}k</value>
+	</data>
+	<data name="ModificationDisplay_WindowBackground" xml:space="preserve">
+		<value>窗口背景</value>
+	</data>
+	<data name="ModificationDisplay_TargetCastBarCountdown" xml:space="preserve">
+		<value>目标咏唱条倒计时</value>
+	</data>
+	<data name="ModificationDisplay_SuppressDialogAdvance" xml:space="preserve">
+		<value>对话推进抑制</value>
+	</data>
+	<data name="ModificationDisplay_StickyShopCategories" xml:space="preserve">
+		<value>商店类别记忆</value>
+	</data>
+	<data name="ModificationDisplay_SkipTeleportConfirm" xml:space="preserve">
+		<value>跳过传送确认</value>
+	</data>
+	<data name="ModificationDisplay_ShowAetherCurrents" xml:space="preserve">
+		<value>显示风脉泉</value>
+	</data>
+	<data name="ModificationDisplay_SelectNextLootItem" xml:space="preserve">
+		<value>自动切换下一条战利品</value>
+	</data>
+	<data name="ModificationDisplay_SaddlebagSearchBar" xml:space="preserve">
+		<value>鞍囊搜索栏</value>
+	</data>
+	<data name="ModificationDisplay_RetainerSearchBar" xml:space="preserve">
+		<value>雇员搜索栏</value>
+	</data>
+	<data name="ModificationDisplay_ResourceBarPercentages" xml:space="preserve">
+		<value>资源条百分比</value>
+	</data>
+	<data name="ModificationDisplay_ResetInventoryTab" xml:space="preserve">
+		<value>重置物品栏分页</value>
+	</data>
+	<data name="ModificationDisplay_RecentlyLootedWindow" xml:space="preserve">
+		<value>最近战利品窗口</value>
+	</data>
+	<data name="ModificationDisplay_QuestListWindow" xml:space="preserve">
+		<value>任务列表窗口</value>
+	</data>
+	<data name="ModificationDisplay_OpenGlamourDresserToCurrentJob" xml:space="preserve">
+		<value>幻化柜自动切换当前职业</value>
+	</data>
+	<data name="ModificationDisplay_HideGuildhestObjectivePopup" xml:space="preserve">
+		<value>隐藏行会令提示弹窗</value>
+	</data>
+	<data name="ModificationDisplay_HideMpBars" xml:space="preserve">
+		<value>隐藏 MP 条</value>
+	</data>
+	<data name="ModificationDisplay_HideUnwantedBanners" xml:space="preserve">
+		<value>隐藏干扰横幅</value>
+	</data>
+	<data name="ModificationDisplay_HUDCoordinates" xml:space="preserve">
+		<value>HUD 坐标</value>
+	</data>
+	<data name="ModificationDisplay_InstancedWaymarks" xml:space="preserve">
+		<value>独立标点</value>
+	</data>
+	<data name="ModificationDisplay_InventorySearchBar" xml:space="preserve">
+		<value>物品栏搜索栏</value>
+	</data>
+	<data name="ModificationDisplay_ListInventory" xml:space="preserve">
+		<value>物品列表窗口</value>
+	</data>
+	<data name="ModificationDisplay_LocationDisplay" xml:space="preserve">
+		<value>位置显示</value>
+	</data>
+	<data name="ModificationDisplay_MacroLineNumbers" xml:space="preserve">
+		<value>宏行号</value>
+	</data>
+	<data name="ModificationDisplay_MacroTooltips" xml:space="preserve">
+		<value>宏提示</value>
+	</data>
+	<data name="ModificationDisplay_DebugCustomAddon" xml:space="preserve">
+		<value>调试 CustomAddon</value>
+	</data>
+	<data name="ModificationDisplay_DebugGameModification" xml:space="preserve">
+		<value>调试 GameModification</value>
+	</data>
+	<data name="ModificationDisplay_SampleGameModification" xml:space="preserve">
+		<value>示例名称</value>
+	</data>
+	<data name="ModificationDisplay_BetterCursor" xml:space="preserve">
+		<value>鼠标优化</value>
+	</data>
+	<data name="ModificationDisplay_BetterInterruptableCastBars" xml:space="preserve">
+		<value>醒目可打断咏唱条</value>
+	</data>
+	<data name="ModificationDisplay_BetterQuestMapLink" xml:space="preserve">
+		<value>优化任务地图链接</value>
+	</data>
+	<data name="ModificationDisplay_CastBarAetheryteNames" xml:space="preserve">
+		<value>咏唱条显示以太水晶名称</value>
+	</data>
+	<data name="ModificationDisplay_CurrencyOverlay" xml:space="preserve">
+		<value>货币叠加层</value>
+	</data>
+	<data name="ModificationDisplay_DraggableWindowDeadSpace" xml:space="preserve">
+		<value>拖动窗口空白处</value>
+	</data>
+	<data name="ModificationDisplay_DutyTimer" xml:space="preserve">
+		<value>任务计时器</value>
+	</data>
+	<data name="ModificationDisplay_DutyLootPreview" xml:space="preserve">
+		<value>任务战利品预览</value>
+	</data>
+	<data name="ModificationDisplay_EnhancedLootWindow" xml:space="preserve">
+		<value>强化战利品窗口</value>
+	</data>
+	<data name="ModificationDisplay_FadeLootButton" xml:space="preserve">
+		<value>战利品按钮渐隐</value>
+	</data>
+	<data name="ModificationDisplay_FadeUnavailableActions" xml:space="preserve">
+		<value>无法施放动作渐隐</value>
+	</data>
+	<data name="ModificationDisplay_FasterScroll" xml:space="preserve">
+		<value>快速滚动条</value>
+	</data>
+	<data name="ModificationDisplay_FastMouseClick" xml:space="preserve">
+		<value>快速鼠标点击</value>
+	</data>
+	<data name="ModificationDisplay_FocusTargetLock" xml:space="preserve">
+		<value>焦点目标锁定</value>
+	</data>
+	<data name="ModificationDisplay_ForcedCutsceneSounds" xml:space="preserve">
+		<value>强制过场音效</value>
+	</data>
+	<data name="ModificationDisplay_HUDPresets" xml:space="preserve">
+		<value>HUD 预设</value>
+	</data>
+	<data name="ModificationDisplay_FateListWindow" xml:space="preserve">
+		<value>Fate列表窗口</value>
+	</data>
+	<data name="ModificationDisplay_PetSizeContextMenu" xml:space="preserve">
+		<value>召唤兽尺寸菜单</value>
+	</data>
+	<data name="PetSize_MenuTitle" xml:space="preserve">
+		<value>召唤兽尺寸</value>
+	</data>
+	<data name="PetSize_OptionLarge" xml:space="preserve">
+		<value>大</value>
+	</data>
+	<data name="PetSize_OptionMedium" xml:space="preserve">
+		<value>中</value>
+	</data>
+	<data name="PetSize_OptionSmall" xml:space="preserve">
+		<value>小</value>
+	</data>
+	<data name="ModificationDisplay_MissingJobStoneLockout" xml:space="preserve">
+		<value>灵魂水晶锁定</value>
+	</data>
+	<data name="ModificationDisplay_GearsetRedirect" xml:space="preserve">
+		<value>套装重定向</value>
+	</data>
+	<data name="EnhancedLootWindow_CategorySettings" xml:space="preserve">
+		<value>设置</value>
+	</data>
+	<data name="EnhancedLootWindow_ConfigTitle" xml:space="preserve">
+		<value>强化战利品窗口配置</value>
+	</data>
+	<data name="EnhancedLootWindow_LabelMarkAlreadyObtained" xml:space="preserve">
+		<value>标记已解锁物品</value>
+	</data>
+	<data name="EnhancedLootWindow_LabelMarkUnobtainable" xml:space="preserve">
+		<value>标记无法获取的物品</value>
+	</data>
+	<data name="FadeLootButton_CategoryStyleSettings" xml:space="preserve">
+		<value>样式设置</value>
+	</data>
+	<data name="FadeLootButton_ConfigTitle" xml:space="preserve">
+		<value>战利品按钮渐隐配置</value>
+	</data>
+	<data name="FadeLootButton_LabelFadePercentage" xml:space="preserve">
+		<value>渐隐百分比</value>
+	</data>
+	<data name="FadeUnavailableActions_CategoryFeatureToggles" xml:space="preserve">
+		<value>功能开关</value>
+	</data>
+	<data name="FadeUnavailableActions_CategoryStyleSettings" xml:space="preserve">
+		<value>样式设置</value>
+	</data>
+	<data name="FadeUnavailableActions_ConfigTitle" xml:space="preserve">
+		<value>无法施放动作渐隐配置</value>
+	</data>
+	<data name="FadeUnavailableActions_LabelApplyToFrame" xml:space="preserve">
+		<value>同时应用于外框</value>
+	</data>
+	<data name="FadeUnavailableActions_LabelApplyToSync" xml:space="preserve">
+		<value>仅作用于因同步限制的动作</value>
+	</data>
+	<data name="FadeUnavailableActions_LabelFadePercentage" xml:space="preserve">
+		<value>渐隐百分比</value>
+	</data>
+	<data name="FadeUnavailableActions_LabelReddenOutOfRange" xml:space="preserve">
+		<value>超出距离时转红</value>
+	</data>
+	<data name="FadeUnavailableActions_LabelReddenPercentage" xml:space="preserve">
+		<value>染红强度</value>
+	</data>
+	<data name="FasterScroll_CategorySettings" xml:space="preserve">
+		<value>设置</value>
+	</data>
+	<data name="FasterScroll_ConfigTitle" xml:space="preserve">
+		<value>快速滚动条配置</value>
+	</data>
+	<data name="FasterScroll_LabelSpeedMultiplier" xml:space="preserve">
+		<value>速度倍率</value>
+	</data>
+	<data name="ForcedCutsceneSounds_CategoryGeneral" xml:space="preserve">
+		<value>常规</value>
+	</data>
+	<data name="ForcedCutsceneSounds_CategorySpecial" xml:space="preserve">
+		<value>特殊</value>
+	</data>
+	<data name="ForcedCutsceneSounds_CategoryToggles" xml:space="preserve">
+		<value>开关</value>
+	</data>
+	<data name="ForcedCutsceneSounds_ConfigTitle" xml:space="preserve">
+		<value>强制过场音效配置</value>
+	</data>
+	<data name="ForcedCutsceneSounds_DisableMsq" xml:space="preserve">
+		<value>在主线随机本中禁用</value>
+	</data>
+	<data name="ForcedCutsceneSounds_RestoreMuteState" xml:space="preserve">
+		<value>过场结束后恢复静音状态</value>
+	</data>
+	<data name="ForcedCutsceneSounds_UnmuteBgm" xml:space="preserve">
+		<value>取消背景音乐静音</value>
+	</data>
+	<data name="ForcedCutsceneSounds_UnmuteEnv" xml:space="preserve">
+		<value>取消环境音静音</value>
+	</data>
+	<data name="ForcedCutsceneSounds_UnmuteMaster" xml:space="preserve">
+		<value>取消主音量静音</value>
+	</data>
+	<data name="ForcedCutsceneSounds_UnmutePerform" xml:space="preserve">
+		<value>取消演奏静音</value>
+	</data>
+	<data name="ForcedCutsceneSounds_UnmuteSe" xml:space="preserve">
+		<value>取消音效静音</value>
+	</data>
+	<data name="ForcedCutsceneSounds_UnmuteSystem" xml:space="preserve">
+		<value>取消系统音静音</value>
+	</data>
+	<data name="ForcedCutsceneSounds_UnmuteVoice" xml:space="preserve">
+		<value>取消语音静音</value>
+	</data>
+	<data name="GearsetRedirect_ConfigTitle" xml:space="preserve">
+		<value>套装重定向配置</value>
+	</data>
+	<data name="GearsetRedirect_AddRedirectionTitle" xml:space="preserve">
+		<value>新增套装重定向</value>
+	</data>
+	<data name="GearsetRedirect_SortAlphabetical" xml:space="preserve">
+		<value>按字母顺序</value>
+	</data>
+	<data name="GearsetRedirect_SortId" xml:space="preserve">
+		<value>按ID</value>
+	</data>
+	<data name="HideUnwantedBanners_ConfigTitle" xml:space="preserve">
+		<value>隐藏干扰横幅配置</value>
+	</data>
+	<data name="InstancedWaymarks_RenameMenuLabel" xml:space="preserve">
+		<value>重命名</value>
+	</data>
+	<data name="InstancedWaymarks_RenameWindowTitle" xml:space="preserve">
+		<value>标点重命名窗口</value>
+	</data>
+	<data name="DebugCustomAddon_Title" xml:space="preserve">
+		<value>调试插件窗口</value>
+	</data>
+	<data name="ResourceBarPercentages_ApplyToPartyMembers" xml:space="preserve">
+		<value>应用到队员</value>
+	</data>
+	<data name="ResourceBarPercentages_ApplyToPlayer" xml:space="preserve">
+		<value>应用到玩家</value>
+	</data>
+	<data name="ResourceBarPercentages_CategoryExtra" xml:space="preserve">
+		<value>扩展</value>
+	</data>
+	<data name="ResourceBarPercentages_CategoryParameterWidget" xml:space="preserve">
+		<value>参数窗口</value>
+	</data>
+	<data name="ResourceBarPercentages_CategoryPartyList" xml:space="preserve">
+		<value>队伍列表</value>
+	</data>
+	<data name="ResourceBarPercentages_CategoryPercentageFormat" xml:space="preserve">
+		<value>百分比格式</value>
+	</data>
+	<data name="ResourceBarPercentages_CategoryPercentageSign" xml:space="preserve">
+		<value>百分比符号</value>
+	</data>
+	<data name="ResourceBarPercentages_ChangeCp" xml:space="preserve">
+		<value>切换 CP</value>
+	</data>
+	<data name="ResourceBarPercentages_ChangeGp" xml:space="preserve">
+		<value>切换 GP</value>
+	</data>
+	<data name="ResourceBarPercentages_ChangeHp" xml:space="preserve">
+		<value>切换 HP</value>
+	</data>
+	<data name="ResourceBarPercentages_ChangeMp" xml:space="preserve">
+		<value>切换 MP</value>
+	</data>
+	<data name="ResourceBarPercentages_ConfigTitle" xml:space="preserve">
+		<value>资源条百分比配置</value>
+	</data>
+	<data name="ResourceBarPercentages_DecimalPlaces" xml:space="preserve">
+		<value>小数位数</value>
+	</data>
+	<data name="ResourceBarPercentages_DeadOrAliveMode" xml:space="preserve">
+		<value>生死模式</value>
+	</data>
+	<data name="ResourceBarPercentages_ShowDecimalsBelowHundred" xml:space="preserve">
+		<value>仅在低于 100% 时显示小数</value>
+	</data>
+	<data name="ResourceBarPercentages_ShowOnParameterWidget" xml:space="preserve">
+		<value>在参数窗口显示</value>
+	</data>
+	<data name="ResourceBarPercentages_ShowOnPartyList" xml:space="preserve">
+		<value>在队伍列表显示</value>
+	</data>
+	<data name="ResourceBarPercentages_ShowPercentageSign" xml:space="preserve">
+		<value>显示 % 符号</value>
+	</data>
+	<data name="ResourceBarPercentages_StatusAlive" xml:space="preserve">
+		<value>存活</value>
+	</data>
+	<data name="ResourceBarPercentages_StatusDead" xml:space="preserve">
+		<value>战倒</value>
+	</data>
+	<data name="ListInventory_Title" xml:space="preserve">
+		<value>物品列表</value>
+	</data>
+	<data name="ListInventory_FilterAlphabetically" xml:space="preserve">
+		<value>按字母排序</value>
+	</data>
+	<data name="ListInventory_FilterQuantity" xml:space="preserve">
+		<value>数量</value>
+	</data>
+	<data name="ListInventory_FilterLevel" xml:space="preserve">
+		<value>等级</value>
+	</data>
+	<data name="ListInventory_FilterItemLevel" xml:space="preserve">
+		<value>物品品级</value>
+	</data>
+	<data name="ListInventory_FilterRarity" xml:space="preserve">
+		<value>稀有度</value>
+	</data>
+	<data name="ListInventory_FilterItemId" xml:space="preserve">
+		<value>物品 ID</value>
+	</data>
+	<data name="ListInventory_FilterItemCategory" xml:space="preserve">
+		<value>物品类别</value>
+	</data>
+	<data name="RecentlyLootedWindow_Title" xml:space="preserve">
+		<value>最近战利品</value>
+	</data>
+	<data name="QuestListWindow_Title" xml:space="preserve">
+		<value>任务列表</value>
+	</data>
+	<data name="QuestListWindow_FilterAlphabetically" xml:space="preserve">
+		<value>按字母排序</value>
+	</data>
+	<data name="QuestListWindow_FilterDistance" xml:space="preserve">
+		<value>距离</value>
+	</data>
+	<data name="QuestListWindow_FilterIssuerName" xml:space="preserve">
+		<value>委托人姓名</value>
+	</data>
+	<data name="QuestListWindow_FilterLevel" xml:space="preserve">
+		<value>等级</value>
+	</data>
+	<data name="QuestListWindow_FilterType" xml:space="preserve">
+		<value>类型</value>
+	</data>
+	<data name="ShowAetherCurrents_Tooltip" xml:space="preserve">
+		<value>风脉泉</value>
+	</data>
+	<data name="Title_DutyLootPreview" xml:space="preserve">
+		<value>任务战利品预览</value>
+	</data>
+	<data name="VersionLabelFormat" xml:space="preserve">
+		<value>版本 {0}</value>
+	</data>
+</root>

--- a/VanillaPlus/Utilities/Localization.cs
+++ b/VanillaPlus/Utilities/Localization.cs
@@ -1,0 +1,55 @@
+using System.Globalization;
+using System.Resources;
+
+namespace VanillaPlus.Utilities;
+
+public static class Localization {
+    private static readonly ResourceManager ResourceManager = new("VanillaPlus.Resources.Strings", typeof(Localization).Assembly);
+    private static CultureInfo? overrideCulture;
+
+    public static CultureInfo CurrentCulture {
+        get {
+            if (overrideCulture is not null) {
+                return overrideCulture;
+            }
+
+            if (global::VanillaPlus.Services.PluginInterface is null) {
+                return CultureInfo.InvariantCulture;
+            }
+
+            return MapLanguageToCulture(global::VanillaPlus.Services.PluginInterface.UiLanguage);
+        }
+    }
+
+    public static void SetOverrideCulture(CultureInfo? culture)
+        => overrideCulture = culture;
+
+    public static string GetString(string resourceKey, params object[] formatArguments) {
+        if (string.IsNullOrEmpty(resourceKey)) {
+            return string.Empty;
+        }
+
+        var value = ResourceManager.GetString(resourceKey, CurrentCulture)
+                    ?? ResourceManager.GetString(resourceKey, CultureInfo.InvariantCulture)
+                    ?? resourceKey;
+
+        return formatArguments.Length > 0
+            ? string.Format(CurrentCulture, value, formatArguments)
+            : value;
+    }
+
+    public static string Strings(string resourceKey, params object[] formatArguments)
+        => GetString(resourceKey, formatArguments);
+
+    private static CultureInfo MapLanguageToCulture(object? language) {
+        var languageName = language?.ToString();
+
+        return languageName switch {
+            "ja" => CultureInfo.GetCultureInfo("ja-JP"),
+            "zh" => CultureInfo.GetCultureInfo("zh-CN"),
+            // "de" => CultureInfo.GetCultureInfo("de-DE"),
+            // "fr" => CultureInfo.GetCultureInfo("fr-FR"),
+            _ => CultureInfo.GetCultureInfo("en-US"),
+        };
+    }
+}

--- a/VanillaPlus/VanillaPlus.cs
+++ b/VanillaPlus/VanillaPlus.cs
@@ -18,20 +18,20 @@ public sealed class VanillaPlus : IDalamudPlugin {
 
         System.AddonModificationBrowser = new AddonModificationBrowser {
             InternalName = "VanillaPlusConfig",
-            Title = "Vanilla Plus Modification Browser",
+            Title = Strings("ModificationBrowserTitle"),
             Size = new Vector2(836.0f, 650.0f),
         };
 
         Services.CommandManager.AddHandler("/vanillaplus", new CommandInfo(Handler) {
             DisplayOrder = 1,
             ShowInHelp = true,
-            HelpMessage = "Open Game Modification Browser",
+            HelpMessage = Strings("CommandHelpOpenBrowser"),
         });
 
         Services.CommandManager.AddHandler("/plus", new CommandInfo(Handler) {
             DisplayOrder = 2,
             ShowInHelp = true,
-            HelpMessage = "Open Game Modification Browser",
+            HelpMessage = Strings("CommandHelpOpenBrowser"),
         });
 
         System.WindowSystem = new WindowSystem("VanillaPlus");


### PR DESCRIPTION
Converted the hardcoded strings to proper localized ones. Since CheapLoc is on its way out, I used the standard resx way.  
Added a global `Strings()` helper so grabbing localized text or templates is a lot cleaner.

Only Chinese and Japanese have been added so far, consider adding more languages in crowdin or elsewhere.

Something that haven't been updated yet:
* Some strings are hardcoded in `KamiToolKit`
* Some `SortingOptions` like `"Visibility", "Alphabetical" ` are hardcoded in KamiToolKit using strings as switch conditions
* Some of the concatenated strings in the corners
* The section titles are defined in the Description, and may require refactoring to be localized

<img width="645" height="486" alt="snipaste_20251220_075031" src="https://github.com/user-attachments/assets/169fd50e-7f6f-482e-ad13-08dd598f1160" />


<img width="645" height="486" alt="snipaste_20251220_075039" src="https://github.com/user-attachments/assets/df3469dd-712a-4965-9228-0ec7e8ddfe09" />


<img width="351" height="236" alt="snipaste_20251220_080213" src="https://github.com/user-attachments/assets/b46080b3-854a-459f-adfc-ac6ea8d65e39" />
