### PR TITLE
Hide dead enemy markers when dead enemy nameplates are hidden

### DIFF
--- a/VanillaPlus/Features/HideDeadEnemyNamePlates/HideDeadEnemyNamePlates.cs
+++ b/VanillaPlus/Features/HideDeadEnemyNamePlates/HideDeadEnemyNamePlates.cs
@@ -27,6 +27,7 @@ public class HideDeadEnemyNamePlates : GameModification {
         foreach (var handler in handlers) {
             if (handler is { NamePlateKind: NamePlateKind.BattleNpcEnemy, GameObject.IsDead: true }) {
                 handler.VisibilityFlags = 0;
+                handler.MarkerIconId = 0;
             }
         }
     }


### PR DESCRIPTION
Should hopefully fix an issue where enemy markers (e.g. regular square/circle, or certain chain markers in Occult Crescent) were visible even though the plate itself was hidden.