### PR TITLE
Fix DutyLootNode tooltips

### DIFF
--- a/VanillaPlus/Features/DutyLootPreview/DutyLootNode.cs
+++ b/VanillaPlus/Features/DutyLootPreview/DutyLootNode.cs
@@ -67,14 +67,10 @@ public unsafe class DutyLootNode : SimpleComponentNode {
 
         CollisionNode.AddEvent(AtkEventType.MouseOver, () => {
             IsHovered = true;
-
-            if (Item is null) return;
-            CollisionNode.ItemTooltip = Item.ItemId;
         });
         
         CollisionNode.AddEvent(AtkEventType.MouseOut, () => {
             IsHovered = false;
-            CollisionNode.HideTooltip();
         });
 
         CollisionNode.AddEvent(AtkEventType.MouseClick, (_, _, _, _, atkEventData) => {
@@ -109,6 +105,7 @@ public unsafe class DutyLootNode : SimpleComponentNode {
             iconNode.Count = 1; // value.Quantity;
             infoIconNode.TextTooltip = string.Join("\n", value.Sources);
             checkmarkIconNode.IsVisible = value.IsUnlocked;
+            CollisionNode.ItemTooltip = Item.ItemId;
         }
     }
     


### PR DESCRIPTION
When hovering an item for the first time, it wouldn't show a tooltip.

https://github.com/user-attachments/assets/f9d0faaf-75b5-4f51-82d0-a81842effbed

