### PR TITLE
Skip Compatibility check for unloaded plugins

### DIFF
--- a/VanillaPlus/Classes/CompatibilityModule.cs
+++ b/VanillaPlus/Classes/CompatibilityModule.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace VanillaPlus.Classes;
 
@@ -7,7 +7,7 @@ public abstract class CompatibilityModule(string? allowedVersion = null) {
 
     protected bool IsPluginLoaded(string internalName) {
         foreach (var installedPlugin in Services.PluginInterface.InstalledPlugins) {
-            if (installedPlugin.InternalName != internalName) continue;
+            if (!installedPlugin.IsLoaded || installedPlugin.InternalName != internalName) continue;
 
             // If the installed version is less than the allowed version, return true.
             if (allowedVersion is not null) {


### PR DESCRIPTION
Fixes an issue where the plugin checks compatibility against obsolete unloaded development plugins

Closes #96 