### PR TITLE
Add Suppress Shared Strategy Boards Tweak

### DIFF
--- a/VanillaPlus/Features/SuppressSharedBoards/SuppressSharedBoards.cs
+++ b/VanillaPlus/Features/SuppressSharedBoards/SuppressSharedBoards.cs
@@ -1,0 +1,43 @@
+using Dalamud.Hooking;
+using Dalamud.Utility.Signatures;
+using VanillaPlus.Classes;
+using VanillaPlus.Enums;
+
+namespace VanillaPlus.Features.SuppressSharedBoards;
+
+public class SuppressSharedBoards : GameModification {
+    public override ModificationInfo ModificationInfo => new() {
+        DisplayName = "Suppress Shared Strategy Boards",
+        Description = "Completely suppresses any shared Strategy Board.",
+        Type = ModificationType.GameBehavior,
+        Authors = ["Treezy"]
+    };
+
+    // TODO: Replace with CS in 7.5
+    // https://github.com/aers/FFXIVClientStructs/blob/main/FFXIVClientStructs/FFXIV/Client/UI/Misc/TofuHelper.cs#L58
+    private delegate void ShowSharedNotificationDelegate(nint thisPtr, bool isNotRealTimeSharing, bool openNotif);
+    [Signature("48 89 6C 24 ?? 56 41 56 41 57 48 83 EC ?? 4C 8B F9 0F B6 EA", DetourName = nameof(ShowSharedNotificationDetour))]
+    private Hook<ShowSharedNotificationDelegate>? showSharedNotificationHook;
+
+    // https://github.com/aers/FFXIVClientStructs/blob/main/FFXIVClientStructs/FFXIV/Client/UI/Misc/TofuHelper.cs#L50
+    private delegate void SaveBoardAndPlaySoundDelegate(nint thisPtr, nint packetData, nint boardInfo, uint boardIndexInSharedFolder, uint totalBoardsInSharedFolder);
+    [Signature("E8 ?? ?? ?? ?? 40 80 F5", DetourName = nameof(SaveBoardAndPlaySoundDetour))]
+    private Hook<SaveBoardAndPlaySoundDelegate>? saveBoardAndPlaySoundHook;
+
+    public override void OnEnable() {
+        Services.GameInteropProvider.InitializeFromAttributes(this);
+        showSharedNotificationHook?.Enable();
+        saveBoardAndPlaySoundHook?.Enable();
+    }
+
+    public override void OnDisable() {
+        showSharedNotificationHook?.Dispose();
+        showSharedNotificationHook = null;
+        saveBoardAndPlaySoundHook?.Dispose();
+        saveBoardAndPlaySoundHook = null;
+    }
+
+    private void ShowSharedNotificationDetour(nint thisPtr, bool isNotRealTimeSharing, bool openNotif) { }
+
+    private void SaveBoardAndPlaySoundDetour(nint thisPtr, nint packetData, nint boardInfo, uint boardIndexInSharedFolder, uint totalBoardsInSharedFolder) { }
+}


### PR DESCRIPTION
Manually patches out the two calls responsible for the notification when a shared board is received. Its important to maintain the structure of this function as the player is required to send a return packet to verify they received the board. If the player does not send this, the server will resend the board to the player 2 more times with 20 seconds in between. The verification packet send function: `E8 ?? ?? ?? ?? 44 8B CE 44 89 6C 24`

The game uses board sharing, live sharing and folder sharing with the same opcode and thus same function. This suppresses all types of sharing.