### PR TITLE
Localization update for 1.2.5.5

### DIFF
--- a/VanillaPlus/Features/BetterSelectString/BetterSelectString.cs
+++ b/VanillaPlus/Features/BetterSelectString/BetterSelectString.cs
@@ -11,8 +11,8 @@ namespace VanillaPlus.Features.BetterSelectString;
 
 public unsafe class BetterSelectString : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Better Select String",
-        Description = "Allows you to select one of multiple sentences via number.",
+        DisplayName = Strings.ModificationDisplay_BetterSelectString,
+        Description = Strings.ModificationDescription_BetterSelectString,
         Type = ModificationType.UserInterface,
         Authors = [ "MidoriKami" ],
         ChangeLog = [

--- a/VanillaPlus/Features/ClockOverlay/ClockOverlay.cs
+++ b/VanillaPlus/Features/ClockOverlay/ClockOverlay.cs
@@ -42,12 +42,12 @@ public class ClockOverlay : GameModification {
             .AddCheckbox(Strings.ClockOverlay_EnableMoving, nameof(config.IsMoveable))
             .AddDropdown<ClockType>(Strings.ClockOverlay_TimeSource, nameof(config.Type));
 
-        configWindow.AddCategory("Visual Style")
-            .AddColorEdit("Text Color", nameof(config.TextColor))
-            .AddColorEdit("Text Outline", nameof(config.TextOutlineColor))
-            .AddIntSlider("Font Size", 8, 32, nameof(config.FontSize))
-            .AddDropdown<FontType>("Font", nameof(config.FontType))
-            .AddDropdown<AlignmentType>("Alignment", nameof(config.AlignmentType))
+        configWindow.AddCategory(Strings.ClockOverlay_CategoryVisualStyle)
+            .AddColorEdit(Strings.ClockOverlay_LabelTextColor, nameof(config.TextColor))
+            .AddColorEdit(Strings.ClockOverlay_LabelTextOutline, nameof(config.TextOutlineColor))
+            .AddIntSlider(Strings.ClockOverlay_LabelFontSize, 8, 32, nameof(config.FontSize))
+            .AddDropdown<FontType>(Strings.ClockOverlay_LabelFont, nameof(config.FontType))
+            .AddDropdown<AlignmentType>(Strings.ClockOverlay_LabelAlignment, nameof(config.AlignmentType))
             .AddDropdown<TextFlags>(Strings.ClockOverlay_TextRendering, nameof(config.TextFlags));
         
         OpenConfigAction = configWindow.Toggle;

--- a/VanillaPlus/Features/ConfigSearchBar/SystemConfigSearchBar.cs
+++ b/VanillaPlus/Features/ConfigSearchBar/SystemConfigSearchBar.cs
@@ -13,8 +13,8 @@ namespace VanillaPlus.Features.ConfigSearchBar;
 
 public unsafe class SystemConfigSearchBar : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "System Configuration Search Bar",
-        Description = "Adds a search bar to System Configuration Windows",
+        DisplayName = Strings.ModificationDisplay_SystemConfigSearchBar,
+        Description = Strings.ModificationDescription_SystemConfigSearchBar,
         Type = ModificationType.UserInterface,
         Authors = [ "MidoriKami" ],
         ChangeLog = [
@@ -35,14 +35,14 @@ public unsafe class SystemConfigSearchBar : GameModification {
         config = ConfigSearchBarConfig.Load();
 
         configAddon = new ConfigAddon {
-            Title = "System Config Search Bar Config",
+            Title = Strings.SystemConfigSearchBar_ConfigTitle,
             InternalName = "ConfigSearchBarConfig",
             Config = config,
         };
 
-        configAddon.AddCategory("General")
-            .AddColorEdit("Tab Highlight", nameof(config.TabColor), KnownColor.LimeGreen.Vector())
-            .AddColorEdit("Text Highlight", nameof(config.HighlightColor), KnownColor.Red.Vector());
+        configAddon.AddCategory(Strings.SystemConfigSearchBar_CategoryGeneral)
+            .AddColorEdit(Strings.SystemConfigSearchBar_LabelTabHighlight, nameof(config.TabColor), KnownColor.LimeGreen.Vector())
+            .AddColorEdit(Strings.SystemConfigSearchBar_LabelTextHighlight, nameof(config.HighlightColor), KnownColor.Red.Vector());
 
         OpenConfigAction = configAddon.Toggle;
 

--- a/VanillaPlus/Features/FlagOnCursor/FlagOnCursor.cs
+++ b/VanillaPlus/Features/FlagOnCursor/FlagOnCursor.cs
@@ -9,8 +9,8 @@ namespace VanillaPlus.Features.FlagOnCursor;
 
 public unsafe class FlagOnCursor : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Place Flag on Cursor",
-        Description = "Places a flag on the map for where your cursor is pointing in the world.",
+        DisplayName = Strings.ModificationDisplay_FlagOnCursor,
+        Description = Strings.ModificationDescription_FlagOnCursor,
         Type = ModificationType.UserInterface,
         Authors = [ "QLEDHDTV" ],
         ChangeLog = [
@@ -21,7 +21,7 @@ public unsafe class FlagOnCursor : GameModification {
     private const string CommandName = "/flagthere";
 
     public override void OnEnable() => Services.CommandManager.AddHandler(CommandName, new CommandInfo(OnCommand) {
-        HelpMessage = "Place a flag at mouse position",
+        HelpMessage = Strings.FlagOnCursor_CommandHelpMessage,
         ShowInHelp = true,
     });
 

--- a/VanillaPlus/Features/GearSetReorderButtons/GearSetReorderButtons.cs
+++ b/VanillaPlus/Features/GearSetReorderButtons/GearSetReorderButtons.cs
@@ -12,8 +12,8 @@ namespace VanillaPlus.Features.GearSetReorderButtons;
 
 public unsafe class GearSetReorderButtons : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Gearset Reorder Buttons",
-        Description = "Adds buttons to the gearset list window for easily reordering gearsets.",
+        DisplayName = Strings.ModificationDisplay_GearSetReorderButtons,
+        Description = Strings.ModificationDescription_GearSetReorderButtons,
         Type = ModificationType.UserInterface,
         Authors = ["zajrik"],
         ChangeLog = [

--- a/VanillaPlus/Features/GearSetReorderButtons/Nodes/GearSetListReorderButtonNode.cs
+++ b/VanillaPlus/Features/GearSetReorderButtons/Nodes/GearSetListReorderButtonNode.cs
@@ -17,7 +17,7 @@ public unsafe class GearSetListReorderButtonNode : SimpleComponentNode {
             Icon = ButtonIcon.UpArrow,
             Size = new Vector2(32.0f, 32.0f),
             OnClick = () => AgentGearSet.Instance()->MoveSetUp(GearSetId),
-            TextTooltip = "Move gear set up.",
+            TextTooltip = Strings.GearSetReorderButtons_TooltipMoveUp,
             IsEnabled = false,
         };
 
@@ -26,7 +26,7 @@ public unsafe class GearSetListReorderButtonNode : SimpleComponentNode {
             Size = new Vector2(32.0f, 32.0f),
             Position = new Vector2(28.0f, 0.0f),
             OnClick = () => AgentGearSet.Instance()->MoveSetDown(GearSetId),
-            TextTooltip = "Move gear set down.",
+            TextTooltip = Strings.GearSetReorderButtons_TooltipMoveDown,
             IsEnabled = false,
         };
 

--- a/VanillaPlus/Features/LockChatButton/LockChatButton.cs
+++ b/VanillaPlus/Features/LockChatButton/LockChatButton.cs
@@ -12,8 +12,8 @@ namespace VanillaPlus.Features.LockChatButton;
 
 public unsafe class LockChatButton : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Lock Chat Button",
-        Description = "Adds a button to chatlogs to lock them from moving.",
+        DisplayName = Strings.ModificationDisplay_LockChatButton,
+        Description = Strings.ModificationDescription_LockChatButton,
         Type = ModificationType.UserInterface,
         Authors = ["MidoriKami"],
         ChangeLog = [
@@ -93,7 +93,7 @@ public unsafe class LockChatButton : GameModification {
         var newButton = new PadlockButtonNode {
             Size = new Vector2(20.0f, 24.0f),
             IsLocked = data.IsLocked,
-            TextTooltip = data.IsLocked ? "[VanillaPlus] Unlock Chat Movement" : "[VanillaPlus] Lock Chat Movement",
+            TextTooltip = data.IsLocked ? Strings.LockChatButton_TooltipUnlock : Strings.LockChatButton_TooltipLock,
         };
 
         newButton.OnClick = () => OnLockButtonClicked(newButton);
@@ -138,7 +138,7 @@ public unsafe class LockChatButton : GameModification {
             Size = new Vector2(20.0f, 24.0f), 
             IsLocked = data.IsLocked, 
             Position = positioningNode->Position + new Vector2(32.0f, 2.0f), 
-            TextTooltip = data.IsLocked ? "[VanillaPlus] Unlock Chat Movement" : "[VanillaPlus] Lock Chat Movement",
+            TextTooltip = data.IsLocked ? Strings.LockChatButton_TooltipUnlock : Strings.LockChatButton_TooltipLock,
         };
 
         newButton.OnClick = () => OnLockButtonClicked(newButton);
@@ -165,7 +165,7 @@ public unsafe class LockChatButton : GameModification {
             buttonNode.Value.IsLocked = data.IsLocked;
         }
 
-        thisButton.TextTooltip = data.IsLocked ? "[VanillaPlus] Unlock Chat Movement" : "[VanillaPlus] Lock Chat Movement";
+        thisButton.TextTooltip = data.IsLocked ? Strings.LockChatButton_TooltipUnlock : Strings.LockChatButton_TooltipLock;
         thisButton.ShowTooltip();
     }
 

--- a/VanillaPlus/Features/ReverseCharacterPanel/ReverseCharacterPanel.cs
+++ b/VanillaPlus/Features/ReverseCharacterPanel/ReverseCharacterPanel.cs
@@ -8,8 +8,8 @@ namespace VanillaPlus.Features.ReverseCharacterPanel;
 
 public unsafe class ReverseCharacterPanel : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Reverse Character Panel",
-        Description = "Switches where the character information and character portraits are in the Character window.",
+        DisplayName = Strings.ModificationDisplay_ReverseCharacterPanel,
+        Description = Strings.ModificationDescription_ReverseCharacterPanel,
         Type = ModificationType.UserInterface,
         Authors = [ "MidoriKami" ],
         ChangeLog = [

--- a/VanillaPlus/Features/ShowAetherytesOnTop/ShowAetherytesOnTop.cs
+++ b/VanillaPlus/Features/ShowAetherytesOnTop/ShowAetherytesOnTop.cs
@@ -11,8 +11,8 @@ namespace VanillaPlus.Features.ShowAetherytesOnTop;
 
 public unsafe class ShowAetherytesOnTop : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Show Aetherytes on Top",
-        Description = "Forces aetherytes to always show on top of other map markers.",
+        DisplayName = Strings.ModificationDisplay_ShowAetherytesOnTop,
+        Description = Strings.ModificationDescription_ShowAetherytesOnTop,
         Type = ModificationType.UserInterface,
         SubType = ModificationSubType.Map,
         Authors = [ "MidoriKami" ],

--- a/VanillaPlus/Features/ShowEnemies/ShowEnemies.cs
+++ b/VanillaPlus/Features/ShowEnemies/ShowEnemies.cs
@@ -8,8 +8,8 @@ namespace VanillaPlus.Features.ShowEnemies;
 
 public unsafe class ShowEnemies : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Show Enemies",
-        Description = "Shows icons for enemies players on the map.",
+        DisplayName = Strings.ModificationDisplay_ShowEnemies,
+        Description = Strings.ModificationDescription_ShowEnemies,
         Type = ModificationType.UserInterface,
         SubType = ModificationSubType.Map,
         Authors = [ "MidoriKami" ],

--- a/VanillaPlus/Features/ShowGatheringPoints/ShowGatheringPoints.cs
+++ b/VanillaPlus/Features/ShowGatheringPoints/ShowGatheringPoints.cs
@@ -8,8 +8,8 @@ namespace VanillaPlus.Features.ShowGatheringPoints;
 
 public unsafe class ShowGatheringPoints : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Show Gathering Points",
-        Description = "Shows icons for gathering points on the map.",
+        DisplayName = Strings.ModificationDisplay_ShowGatheringPoints,
+        Description = Strings.ModificationDescription_ShowGatheringPoints,
         Type = ModificationType.UserInterface,
         SubType = ModificationSubType.Map,
         Authors = [ "MidoriKami" ],

--- a/VanillaPlus/Features/ShowPlayers/ShowPlayers.cs
+++ b/VanillaPlus/Features/ShowPlayers/ShowPlayers.cs
@@ -8,8 +8,8 @@ namespace VanillaPlus.Features.ShowPlayers;
 
 public unsafe class ShowPlayersOnMap : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Show Players",
-        Description = "Shows icons for other players on the map.",
+        DisplayName = Strings.ModificationDisplay_ShowPlayers,
+        Description = Strings.ModificationDescription_ShowPlayers,
         Type = ModificationType.UserInterface,
         SubType = ModificationSubType.Map,
         Authors = [ "MidoriKami" ],

--- a/VanillaPlus/Features/ShowTreasureChests/ShowTreasureChests.cs
+++ b/VanillaPlus/Features/ShowTreasureChests/ShowTreasureChests.cs
@@ -8,8 +8,8 @@ namespace VanillaPlus.Features.ShowTreasureChests;
 
 public unsafe class ShowTreasureChests : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Show Treasure Chests",
-        Description = "Shows icons for treasure chests on the map.",
+        DisplayName = Strings.ModificationDisplay_ShowTreasureChests,
+        Description = Strings.ModificationDescription_ShowTreasureChests,
         Type = ModificationType.UserInterface,
         SubType = ModificationSubType.Map,
         Authors = [ "MidoriKami" ],

--- a/VanillaPlus/Features/SkipLoginConfirm/SkipLoginConfirm.cs
+++ b/VanillaPlus/Features/SkipLoginConfirm/SkipLoginConfirm.cs
@@ -9,8 +9,8 @@ namespace VanillaPlus.Features.SkipLoginConfirm;
 
 public unsafe class SkipLoginConfirm : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Skip Login Confirm",
-        Description = "Skips the confirmation window that appears when logging in.",
+        DisplayName = Strings.ModificationDisplay_SkipLoginConfirm,
+        Description = Strings.ModificationDescription_SkipLoginConfirm,
         Type = ModificationType.GameBehavior,
         Authors = [ "MidoriKami" ],
         ChangeLog = [

--- a/VanillaPlus/Resources/Strings.Designer.cs
+++ b/VanillaPlus/Resources/Strings.Designer.cs
@@ -3991,5 +3991,356 @@ namespace VanillaPlus.Resources {
                 return ResourceManager.GetString("WondrousTailsProbabilities_ShuffleAverageLabel", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to System Configuration Search Bar.
+        /// </summary>
+        internal static string ModificationDisplay_SystemConfigSearchBar {
+            get {
+                return ResourceManager.GetString("ModificationDisplay_SystemConfigSearchBar", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Adds a search bar to System Configuration Windows.
+        /// </summary>
+        internal static string ModificationDescription_SystemConfigSearchBar {
+            get {
+                return ResourceManager.GetString("ModificationDescription_SystemConfigSearchBar", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to System Config Search Bar Config.
+        /// </summary>
+        internal static string SystemConfigSearchBar_ConfigTitle {
+            get {
+                return ResourceManager.GetString("SystemConfigSearchBar_ConfigTitle", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to General.
+        /// </summary>
+        internal static string SystemConfigSearchBar_CategoryGeneral {
+            get {
+                return ResourceManager.GetString("SystemConfigSearchBar_CategoryGeneral", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Tab Highlight.
+        /// </summary>
+        internal static string SystemConfigSearchBar_LabelTabHighlight {
+            get {
+                return ResourceManager.GetString("SystemConfigSearchBar_LabelTabHighlight", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Text Highlight.
+        /// </summary>
+        internal static string SystemConfigSearchBar_LabelTextHighlight {
+            get {
+                return ResourceManager.GetString("SystemConfigSearchBar_LabelTextHighlight", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Visual Style.
+        /// </summary>
+        internal static string ClockOverlay_CategoryVisualStyle {
+            get {
+                return ResourceManager.GetString("ClockOverlay_CategoryVisualStyle", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Text Color.
+        /// </summary>
+        internal static string ClockOverlay_LabelTextColor {
+            get {
+                return ResourceManager.GetString("ClockOverlay_LabelTextColor", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Text Outline.
+        /// </summary>
+        internal static string ClockOverlay_LabelTextOutline {
+            get {
+                return ResourceManager.GetString("ClockOverlay_LabelTextOutline", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Font Size.
+        /// </summary>
+        internal static string ClockOverlay_LabelFontSize {
+            get {
+                return ResourceManager.GetString("ClockOverlay_LabelFontSize", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Font.
+        /// </summary>
+        internal static string ClockOverlay_LabelFont {
+            get {
+                return ResourceManager.GetString("ClockOverlay_LabelFont", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Alignment.
+        /// </summary>
+        internal static string ClockOverlay_LabelAlignment {
+            get {
+                return ResourceManager.GetString("ClockOverlay_LabelAlignment", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Lock Chat Button.
+        /// </summary>
+        internal static string ModificationDisplay_LockChatButton {
+            get {
+                return ResourceManager.GetString("ModificationDisplay_LockChatButton", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Adds a button to chatlogs to lock them from moving.
+        /// </summary>
+        internal static string ModificationDescription_LockChatButton {
+            get {
+                return ResourceManager.GetString("ModificationDescription_LockChatButton", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to [VanillaPlus] Unlock Chat Movement.
+        /// </summary>
+        internal static string LockChatButton_TooltipUnlock {
+            get {
+                return ResourceManager.GetString("LockChatButton_TooltipUnlock", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to [VanillaPlus] Lock Chat Movement.
+        /// </summary>
+        internal static string LockChatButton_TooltipLock {
+            get {
+                return ResourceManager.GetString("LockChatButton_TooltipLock", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Gearset Reorder Buttons.
+        /// </summary>
+        internal static string ModificationDisplay_GearSetReorderButtons {
+            get {
+                return ResourceManager.GetString("ModificationDisplay_GearSetReorderButtons", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Adds buttons to the gearset list window for easily reordering gearsets.
+        /// </summary>
+        internal static string ModificationDescription_GearSetReorderButtons {
+            get {
+                return ResourceManager.GetString("ModificationDescription_GearSetReorderButtons", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Move gear set up..
+        /// </summary>
+        internal static string GearSetReorderButtons_TooltipMoveUp {
+            get {
+                return ResourceManager.GetString("GearSetReorderButtons_TooltipMoveUp", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Move gear set down..
+        /// </summary>
+        internal static string GearSetReorderButtons_TooltipMoveDown {
+            get {
+                return ResourceManager.GetString("GearSetReorderButtons_TooltipMoveDown", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Better Select String.
+        /// </summary>
+        internal static string ModificationDisplay_BetterSelectString {
+            get {
+                return ResourceManager.GetString("ModificationDisplay_BetterSelectString", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Allows you to select one of multiple sentences via number.
+        /// </summary>
+        internal static string ModificationDescription_BetterSelectString {
+            get {
+                return ResourceManager.GetString("ModificationDescription_BetterSelectString", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Place Flag on Cursor.
+        /// </summary>
+        internal static string ModificationDisplay_FlagOnCursor {
+            get {
+                return ResourceManager.GetString("ModificationDisplay_FlagOnCursor", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Places a flag on the map for where your cursor is pointing in the world.
+        /// </summary>
+        internal static string ModificationDescription_FlagOnCursor {
+            get {
+                return ResourceManager.GetString("ModificationDescription_FlagOnCursor", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Place a flag at mouse position.
+        /// </summary>
+        internal static string FlagOnCursor_CommandHelpMessage {
+            get {
+                return ResourceManager.GetString("FlagOnCursor_CommandHelpMessage", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Reverse Character Panel.
+        /// </summary>
+        internal static string ModificationDisplay_ReverseCharacterPanel {
+            get {
+                return ResourceManager.GetString("ModificationDisplay_ReverseCharacterPanel", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Switches where the character information and character portraits are in the Character window.
+        /// </summary>
+        internal static string ModificationDescription_ReverseCharacterPanel {
+            get {
+                return ResourceManager.GetString("ModificationDescription_ReverseCharacterPanel", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Show Aetherytes on Top.
+        /// </summary>
+        internal static string ModificationDisplay_ShowAetherytesOnTop {
+            get {
+                return ResourceManager.GetString("ModificationDisplay_ShowAetherytesOnTop", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Forces aetherytes to always show on top of other map markers.
+        /// </summary>
+        internal static string ModificationDescription_ShowAetherytesOnTop {
+            get {
+                return ResourceManager.GetString("ModificationDescription_ShowAetherytesOnTop", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Show Enemies.
+        /// </summary>
+        internal static string ModificationDisplay_ShowEnemies {
+            get {
+                return ResourceManager.GetString("ModificationDisplay_ShowEnemies", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Shows icons for enemies players on the map.
+        /// </summary>
+        internal static string ModificationDescription_ShowEnemies {
+            get {
+                return ResourceManager.GetString("ModificationDescription_ShowEnemies", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Show Gathering Points.
+        /// </summary>
+        internal static string ModificationDisplay_ShowGatheringPoints {
+            get {
+                return ResourceManager.GetString("ModificationDisplay_ShowGatheringPoints", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Shows icons for gathering points on the map.
+        /// </summary>
+        internal static string ModificationDescription_ShowGatheringPoints {
+            get {
+                return ResourceManager.GetString("ModificationDescription_ShowGatheringPoints", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Show Players.
+        /// </summary>
+        internal static string ModificationDisplay_ShowPlayers {
+            get {
+                return ResourceManager.GetString("ModificationDisplay_ShowPlayers", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Shows icons for other players on the map.
+        /// </summary>
+        internal static string ModificationDescription_ShowPlayers {
+            get {
+                return ResourceManager.GetString("ModificationDescription_ShowPlayers", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Show Treasure Chests.
+        /// </summary>
+        internal static string ModificationDisplay_ShowTreasureChests {
+            get {
+                return ResourceManager.GetString("ModificationDisplay_ShowTreasureChests", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Shows icons for treasure chests on the map.
+        /// </summary>
+        internal static string ModificationDescription_ShowTreasureChests {
+            get {
+                return ResourceManager.GetString("ModificationDescription_ShowTreasureChests", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Skip Login Confirm.
+        /// </summary>
+        internal static string ModificationDisplay_SkipLoginConfirm {
+            get {
+                return ResourceManager.GetString("ModificationDisplay_SkipLoginConfirm", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Skips the confirmation window that appears when logging in.
+        /// </summary>
+        internal static string ModificationDescription_SkipLoginConfirm {
+            get {
+                return ResourceManager.GetString("ModificationDescription_SkipLoginConfirm", resourceCulture);
+            }
+        }
     }
 }

--- a/VanillaPlus/Resources/Strings.resx
+++ b/VanillaPlus/Resources/Strings.resx
@@ -1451,4 +1451,121 @@ This game modification fixes it by always triggering the normal mouse click in a
   <data name="ModificationDescription_InventoryCooldowns" xml:space="preserve">
     <value>Shows the cooldown on items in the inventory.</value>
   </data>
+  <data name="ModificationDisplay_SystemConfigSearchBar" xml:space="preserve">
+    <value>System Configuration Search Bar</value>
+  </data>
+  <data name="ModificationDescription_SystemConfigSearchBar" xml:space="preserve">
+    <value>Adds a search bar to System Configuration Windows</value>
+  </data>
+  <data name="SystemConfigSearchBar_ConfigTitle" xml:space="preserve">
+    <value>System Config Search Bar Config</value>
+  </data>
+  <data name="SystemConfigSearchBar_CategoryGeneral" xml:space="preserve">
+    <value>General</value>
+  </data>
+  <data name="SystemConfigSearchBar_LabelTabHighlight" xml:space="preserve">
+    <value>Tab Highlight</value>
+  </data>
+  <data name="SystemConfigSearchBar_LabelTextHighlight" xml:space="preserve">
+    <value>Text Highlight</value>
+  </data>
+  <data name="ClockOverlay_CategoryVisualStyle" xml:space="preserve">
+    <value>Visual Style</value>
+  </data>
+  <data name="ClockOverlay_LabelTextColor" xml:space="preserve">
+    <value>Text Color</value>
+  </data>
+  <data name="ClockOverlay_LabelTextOutline" xml:space="preserve">
+    <value>Text Outline</value>
+  </data>
+  <data name="ClockOverlay_LabelFontSize" xml:space="preserve">
+    <value>Font Size</value>
+  </data>
+  <data name="ClockOverlay_LabelFont" xml:space="preserve">
+    <value>Font</value>
+  </data>
+  <data name="ClockOverlay_LabelAlignment" xml:space="preserve">
+    <value>Alignment</value>
+  </data>
+  <data name="ModificationDisplay_LockChatButton" xml:space="preserve">
+    <value>Lock Chat Button</value>
+  </data>
+  <data name="ModificationDescription_LockChatButton" xml:space="preserve">
+    <value>Adds a button to chatlogs to lock them from moving.</value>
+  </data>
+  <data name="LockChatButton_TooltipUnlock" xml:space="preserve">
+    <value>[VanillaPlus] Unlock Chat Movement</value>
+  </data>
+  <data name="LockChatButton_TooltipLock" xml:space="preserve">
+    <value>[VanillaPlus] Lock Chat Movement</value>
+  </data>
+  <data name="ModificationDisplay_GearSetReorderButtons" xml:space="preserve">
+    <value>Gearset Reorder Buttons</value>
+  </data>
+  <data name="ModificationDescription_GearSetReorderButtons" xml:space="preserve">
+    <value>Adds buttons to the gearset list window for easily reordering gearsets.</value>
+  </data>
+  <data name="GearSetReorderButtons_TooltipMoveUp" xml:space="preserve">
+    <value>Move gear set up.</value>
+  </data>
+  <data name="GearSetReorderButtons_TooltipMoveDown" xml:space="preserve">
+    <value>Move gear set down.</value>
+  </data>
+  <data name="ModificationDisplay_BetterSelectString" xml:space="preserve">
+    <value>Better Select String</value>
+  </data>
+  <data name="ModificationDescription_BetterSelectString" xml:space="preserve">
+    <value>Allows you to select one of multiple sentences via number.</value>
+  </data>
+  <data name="ModificationDisplay_FlagOnCursor" xml:space="preserve">
+    <value>Place Flag on Cursor</value>
+  </data>
+  <data name="ModificationDescription_FlagOnCursor" xml:space="preserve">
+    <value>Places a flag on the map for where your cursor is pointing in the world.</value>
+  </data>
+  <data name="FlagOnCursor_CommandHelpMessage" xml:space="preserve">
+    <value>Place a flag at mouse position</value>
+  </data>
+  <data name="ModificationDisplay_ReverseCharacterPanel" xml:space="preserve">
+    <value>Reverse Character Panel</value>
+  </data>
+  <data name="ModificationDescription_ReverseCharacterPanel" xml:space="preserve">
+    <value>Switches where the character information and character portraits are in the Character window.</value>
+  </data>
+  <data name="ModificationDisplay_ShowAetherytesOnTop" xml:space="preserve">
+    <value>Show Aetherytes on Top</value>
+  </data>
+  <data name="ModificationDescription_ShowAetherytesOnTop" xml:space="preserve">
+    <value>Forces aetherytes to always show on top of other map markers.</value>
+  </data>
+  <data name="ModificationDisplay_ShowEnemies" xml:space="preserve">
+    <value>Show Enemies</value>
+  </data>
+  <data name="ModificationDescription_ShowEnemies" xml:space="preserve">
+    <value>Shows icons for enemies players on the map.</value>
+  </data>
+  <data name="ModificationDisplay_ShowGatheringPoints" xml:space="preserve">
+    <value>Show Gathering Points</value>
+  </data>
+  <data name="ModificationDescription_ShowGatheringPoints" xml:space="preserve">
+    <value>Shows icons for gathering points on the map.</value>
+  </data>
+  <data name="ModificationDisplay_ShowPlayers" xml:space="preserve">
+    <value>Show Players</value>
+  </data>
+  <data name="ModificationDescription_ShowPlayers" xml:space="preserve">
+    <value>Shows icons for other players on the map.</value>
+  </data>
+  <data name="ModificationDisplay_ShowTreasureChests" xml:space="preserve">
+    <value>Show Treasure Chests</value>
+  </data>
+  <data name="ModificationDescription_ShowTreasureChests" xml:space="preserve">
+    <value>Shows icons for treasure chests on the map.</value>
+  </data>
+  <data name="ModificationDisplay_SkipLoginConfirm" xml:space="preserve">
+    <value>Skip Login Confirm</value>
+  </data>
+  <data name="ModificationDescription_SkipLoginConfirm" xml:space="preserve">
+    <value>Skips the confirmation window that appears when logging in.</value>
+  </data>
 </root>


### PR DESCRIPTION
Sorry it took a while to get this one out. Work has been busy lately, and I haven't had much time to play either, so this update kept getting pushed back.

I'm thinking about letting an agent do these routine localization sweeps on a regular schedule going forward. I'll still review every change manually before sending a PR.

Crowdin is in place, so only the English resx is updated here.

Updated:
* ClockOverlay
* ConfigSearchBar
* GearSetReorderButtons
* LockChatButton
* BetterSelectString
* FlagOnCursor
* ReverseCharacterPanel
* ShowAetherytesOnTop
* ShowEnemies
* ShowGatheringPoints
* ShowPlayers
* ShowTreasureChests
* SkipLoginConfirm

Skipped AprilFools (meme-heavy), ShowEnemies map tooltips (match in-game format), and a few brand/placeholder literals in CosmicExplorationProgressWindow.