### PR TITLE
Add Armoire unlock states to DutyLootPreview

### DIFF
--- a/VanillaPlus/Features/DutyLootPreview/Data/DutyLootItem.cs
+++ b/VanillaPlus/Features/DutyLootPreview/Data/DutyLootItem.cs
@@ -106,7 +106,7 @@ public class DutyLootItem : IComparable {
 
     private int GetCategoryPriority() {
         if (!IsEquipment && IsUnlockable) return 0; // Misc + Unlockable (highest)
-        if (!IsEquipment) return 1;                  // Misc
-        return 2;                                     // Equipment (lowest)
+        if (!IsEquipment) return 1;                 // Misc
+        return 2;                                   // Equipment (lowest)
     }
 }

--- a/VanillaPlus/Features/DutyLootPreview/Data/DutyLootItem.cs
+++ b/VanillaPlus/Features/DutyLootPreview/Data/DutyLootItem.cs
@@ -19,6 +19,8 @@ public class DutyLootItem : IComparable {
     public required byte OrderMinor { get; init; }
     public required bool IsUnlockable { get; init; }
     public required bool IsUnlocked { get; init; }
+    public required bool IsStorableInCabinet { get; init; }
+    public required bool IsStoredInCabinet { get; init; }
     public required bool CanTryOn { get; init; }
     public required List<ReadOnlySeString> Sources { get; init; }
 
@@ -31,6 +33,9 @@ public class DutyLootItem : IComparable {
         var item = Services.DataManager.GetItem(itemId);
         if (item.Icon is 0 || item.Name.IsEmpty) return null;
 
+        var isUnlockable = Services.UnlockState.IsItemUnlockable(item);
+        var isStorableInCabinet = CabinetLookup.Value.ContainsKey(item.RowId);
+
         return new DutyLootItem {
             ItemId = item.RowId,
             IconId = item.Icon,
@@ -38,8 +43,10 @@ public class DutyLootItem : IComparable {
             FilterGroup = item.FilterGroup,
             OrderMajor = item.ItemUICategory.ValueNullable?.OrderMajor ?? 0,
             OrderMinor = item.ItemUICategory.ValueNullable?.OrderMinor ?? 0,
-            IsUnlockable = IsItemUnlockable(item),
-            IsUnlocked = IsItemUnlocked(item),
+            IsUnlockable = isUnlockable,
+            IsUnlocked = isUnlockable && Services.UnlockState.IsItemUnlocked(item),
+            IsStorableInCabinet = isStorableInCabinet,
+            IsStoredInCabinet = isStorableInCabinet && IsInCabinet(item),
             CanTryOn = CheckCanTryOn(item),
             Sources = [],
         };
@@ -48,29 +55,19 @@ public class DutyLootItem : IComparable {
     public bool IsEquipment 
         => FilterGroup is 1 or 2 or 3 or 4 or 45;
 
-    private static bool IsItemUnlockable(Item item) {
-        if (Services.UnlockState.IsItemUnlockable(item))
-            return true;
+    private static unsafe bool IsInCabinet(Item item) {
+        if (!CabinetLookup.Value.TryGetValue(item.RowId, out var cabinetRowId))
+            return false;
 
-        return CabinetLookup.Value.ContainsKey(item.RowId);
-    }
+        // use live data if available
+        if (UIState.Instance()->Cabinet.IsCabinetLoaded())
+            return UIState.Instance()->Cabinet.IsItemInCabinet(cabinetRowId);
 
-    private static unsafe bool IsItemUnlocked(Item item) {
-        if (Services.UnlockState.IsItemUnlockable(item))
-            return Services.UnlockState.IsItemUnlocked(item);
-
-        // Cabinet items
-        if (CabinetLookup.Value.TryGetValue(item.RowId, out var cabinetRowId)) {
-            // use live data if available
-            if (UIState.Instance()->Cabinet.IsCabinetLoaded())
-                return UIState.Instance()->Cabinet.IsItemInCabinet(cabinetRowId);
-
-            // use cached data
-            var itemFinderModule = ItemFinderModule.Instance();
-            (var byteIndex, var bitOffset) = Math.DivRem(cabinetRowId - 1048, 32);
-            if (itemFinderModule->CabinetItemUnlockBits.Length >= byteIndex)
-                return (itemFinderModule->CabinetItemUnlockBits[(int)byteIndex] & (1 << (int)bitOffset)) != 0;
-        }
+        // use cached data
+        var itemFinderModule = ItemFinderModule.Instance();
+        (var byteIndex, var bitOffset) = Math.DivRem(cabinetRowId - 1048, 32);
+        if (itemFinderModule->CabinetItemUnlockBits.Length >= byteIndex)
+            return (itemFinderModule->CabinetItemUnlockBits[(int)byteIndex] & (1 << (int)bitOffset)) != 0;
 
         return false;
     }

--- a/VanillaPlus/Features/DutyLootPreview/Data/DutyLootItem.cs
+++ b/VanillaPlus/Features/DutyLootPreview/Data/DutyLootItem.cs
@@ -1,7 +1,12 @@
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using FFXIVClientStructs.FFXIV.Client.UI.Misc;
 using Lumina.Excel.Sheets;
 using Lumina.Text.ReadOnly;
+using CabinetSheet = Lumina.Excel.Sheets.Cabinet;
 
 namespace VanillaPlus.Features.DutyLootPreview.Data;
 
@@ -17,6 +22,11 @@ public class DutyLootItem : IComparable {
     public required bool CanTryOn { get; init; }
     public required List<ReadOnlySeString> Sources { get; init; }
 
+    private static readonly Lazy<FrozenDictionary<uint, uint>> CabinetLookup = new(()
+        => Services.DataManager.Excel.GetSheet<CabinetSheet>()
+            .Where(row => row.RowId >= 1048 && row.Item.RowId != 0)
+            .ToFrozenDictionary(row => row.Item.RowId, row => row.RowId));
+
     public static DutyLootItem? FromItemId(uint itemId) {
         var item = Services.DataManager.GetItem(itemId);
         if (item.Icon is 0 || item.Name.IsEmpty) return null;
@@ -28,8 +38,8 @@ public class DutyLootItem : IComparable {
             FilterGroup = item.FilterGroup,
             OrderMajor = item.ItemUICategory.ValueNullable?.OrderMajor ?? 0,
             OrderMinor = item.ItemUICategory.ValueNullable?.OrderMinor ?? 0,
-            IsUnlockable = Services.UnlockState.IsItemUnlockable(item),
-            IsUnlocked = Services.UnlockState.IsItemUnlockable(item) && Services.UnlockState.IsItemUnlocked(item),
+            IsUnlockable = IsItemUnlockable(item),
+            IsUnlocked = IsItemUnlocked(item),
             CanTryOn = CheckCanTryOn(item),
             Sources = [],
         };
@@ -37,6 +47,30 @@ public class DutyLootItem : IComparable {
 
     public bool IsEquipment 
         => FilterGroup is 1 or 2 or 3 or 4 or 45;
+
+    private static bool IsItemUnlockable(Item item) {
+        if (Services.UnlockState.IsItemUnlockable(item))
+            return true;
+
+        return CabinetLookup.Value.ContainsKey(item.RowId);
+    }
+
+    private static unsafe bool IsItemUnlocked(Item item) {
+        if (Services.UnlockState.IsItemUnlockable(item))
+            return Services.UnlockState.IsItemUnlocked(item);
+
+        var itemFinderModule = ItemFinderModule.Instance();
+
+        // check against Cabinet cache
+        var cabinetCacheState = Marshal.ReadByte((nint)itemFinderModule + 0xA9);
+        if (cabinetCacheState == 2  && CabinetLookup.Value.TryGetValue(item.RowId, out var cabinetRowId)) {
+            (var byteIndex, var bitOffset) = Math.DivRem(cabinetRowId - 1048, 32);
+            if (itemFinderModule->CabinetItemUnlockBits.Length >= byteIndex)
+                return (itemFinderModule->CabinetItemUnlockBits[(int)byteIndex] & (1 << (int)bitOffset)) != 0;
+        }
+
+        return false;
+    }
 
     // See: https://github.com/Haselnussbomber/HaselCommon/blob/30c023516c0f9771183bbb5c01eb8122765e8bd0/HaselCommon/Services/ItemService.cs#L298-L327
     private static bool CheckCanTryOn(Item item) {

--- a/VanillaPlus/Features/DutyLootPreview/Data/DutyLootItem.cs
+++ b/VanillaPlus/Features/DutyLootPreview/Data/DutyLootItem.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices;
+using FFXIVClientStructs.FFXIV.Client.Game.UI;
 using FFXIVClientStructs.FFXIV.Client.UI.Misc;
 using Lumina.Excel.Sheets;
 using Lumina.Text.ReadOnly;
@@ -59,11 +59,14 @@ public class DutyLootItem : IComparable {
         if (Services.UnlockState.IsItemUnlockable(item))
             return Services.UnlockState.IsItemUnlocked(item);
 
-        var itemFinderModule = ItemFinderModule.Instance();
+        // Cabinet items
+        if (CabinetLookup.Value.TryGetValue(item.RowId, out var cabinetRowId)) {
+            // use live data if available
+            if (UIState.Instance()->Cabinet.IsCabinetLoaded())
+                return UIState.Instance()->Cabinet.IsItemInCabinet(cabinetRowId);
 
-        // check against Cabinet cache
-        var cabinetCacheState = Marshal.ReadByte((nint)itemFinderModule + 0xA9);
-        if (cabinetCacheState == 2  && CabinetLookup.Value.TryGetValue(item.RowId, out var cabinetRowId)) {
+            // use cached data
+            var itemFinderModule = ItemFinderModule.Instance();
             (var byteIndex, var bitOffset) = Math.DivRem(cabinetRowId - 1048, 32);
             if (itemFinderModule->CabinetItemUnlockBits.Length >= byteIndex)
                 return (itemFinderModule->CabinetItemUnlockBits[(int)byteIndex] & (1 << (int)bitOffset)) != 0;

--- a/VanillaPlus/Features/DutyLootPreview/DutyLootAddon.cs
+++ b/VanillaPlus/Features/DutyLootPreview/DutyLootAddon.cs
@@ -15,8 +15,8 @@ namespace VanillaPlus.Features.DutyLootPreview;
 /// The window that shows loot for a duty.
 /// </summary>
 public unsafe class DutyLootPreviewAddon : NativeAddon {
-    private const int VisibleItemCount = 10;
-    private const float ItemHeight = 36.0f;
+    private const int VisibleItemCount = 12;
+    internal const float ItemHeight = 32.0f;
     private const float ItemSpacing = 2.25f;
     private const float FilterBarHeight = 36.0f;
     private const float SeparatorHeight = 4.0f;

--- a/VanillaPlus/Features/DutyLootPreview/DutyLootPreview.cs
+++ b/VanillaPlus/Features/DutyLootPreview/DutyLootPreview.cs
@@ -30,7 +30,7 @@ public class DutyLootPreview : GameModification {
         addonDutyLoot = new DutyLootPreviewAddon {
             InternalName = "DutyLootPreview",
             Title = Strings.Title_DutyLootPreview,
-            Size = new Vector2(300.0f, DutyLootPreviewAddon.WindowHeight),
+            Size = new Vector2(350.0f, DutyLootPreviewAddon.WindowHeight),
             Config = config,
             DataLoader = dataLoader,
         };

--- a/VanillaPlus/Features/DutyLootPreview/Nodes/DutyLootNode.cs
+++ b/VanillaPlus/Features/DutyLootPreview/Nodes/DutyLootNode.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Numerics;
 using FFXIVClientStructs.FFXIV.Client.UI.Agent;
 using FFXIVClientStructs.FFXIV.Client.UI.Misc;
@@ -158,7 +159,7 @@ public unsafe class DutyLootNode : ListItemNode<DutyLootItemView>, IListItemNode
 
         iconNode.IconId = item.IconId;
         itemNameTextNode.String = item.Name;
-        infoIconNode.TextTooltip = string.Join("\n", item.Sources);
+        infoIconNode.TextTooltip = string.Join("\n", item.Sources.Distinct());
         checkmarkIconNode.IsVisible = item.IsUnlocked;
         CollisionNode.ItemTooltip = item.ItemId;
         favoriteStarNode.IsVisible = view.IsFavorite;

--- a/VanillaPlus/Features/DutyLootPreview/Nodes/DutyLootNode.cs
+++ b/VanillaPlus/Features/DutyLootPreview/Nodes/DutyLootNode.cs
@@ -7,7 +7,6 @@ using KamiToolKit.Enums;
 using KamiToolKit.Nodes;
 using KamiToolKit.Premade.Node.Simple;
 using VanillaPlus.Features.DutyLootPreview.Data;
-using VanillaPlus.NativeElements.Nodes;
 using ContextMenu = KamiToolKit.ContextMenu.ContextMenu;
 
 namespace VanillaPlus.Features.DutyLootPreview.Nodes;
@@ -15,7 +14,7 @@ namespace VanillaPlus.Features.DutyLootPreview.Nodes;
 public unsafe class DutyLootNode : ListItemNode<DutyLootItemView>, IListItemNode {
     public static float ItemHeight => 36.0f;
 
-    private readonly IconWithCountNode iconNode;
+    private readonly IconImageNode iconNode;
     private readonly TextNode itemNameTextNode;
     private readonly SimpleImageNode favoriteStarNode;
     private readonly SimpleImageNode infoIconNode;
@@ -25,9 +24,11 @@ public unsafe class DutyLootNode : ListItemNode<DutyLootItemView>, IListItemNode
     public DutyLootNode() {
         contextMenu = new ContextMenu();
 
-        iconNode = new IconWithCountNode();
+        iconNode = new IconImageNode() {
+            TextureSize = new Vector2(32),
+            ImageNodeFlags = ImageNodeFlags.AutoFit,
+        };
         iconNode.AttachNode(this);
-        iconNode.CollisionNode.ShowClickableCursor = true;
 
         favoriteStarNode = new SimpleImageNode {
             TextureCoordinates = new Vector2(96, 0),
@@ -73,7 +74,6 @@ public unsafe class DutyLootNode : ListItemNode<DutyLootItemView>, IListItemNode
         };
 
         CollisionNode.AddEvent(AtkEventType.MouseClick, mouseClickCallback);
-        iconNode.CollisionNode.AddEvent(AtkEventType.MouseClick, mouseClickCallback);
     }
 
     private void OnLeftClick() {
@@ -130,25 +130,27 @@ public unsafe class DutyLootNode : ListItemNode<DutyLootItemView>, IListItemNode
     protected override void OnSizeChanged() {
         base.OnSizeChanged();
 
-        iconNode.Size = new Vector2(Height, Height);
-        iconNode.Position = Vector2.Zero;
+        var iconPadding = new Vector2(4);
+        iconNode.Size = new Vector2(Height, Height) - iconPadding * 2;
+        iconNode.Position = new Vector2(iconPadding.X, iconPadding.Y / 2f);
+        var iconEndPos = iconNode.Position + iconNode.Size + iconPadding;
 
         // Scale star proportionally (original: 20x20 star on 44x44 icon)
         var starSize = iconNode.Height * (20f / 44f);
         favoriteStarNode.Size = new Vector2(starSize, starSize);
 
         // Position in top-right corner, slightly above icon edge
-        favoriteStarNode.Position = new Vector2(iconNode.Width - favoriteStarNode.Width, -2);
+        favoriteStarNode.Position = new Vector2(iconEndPos.X - favoriteStarNode.Width, -2);
 
         var infoSize = Size.Y * 0.6f;
         infoIconNode.Size = new Vector2(infoSize, infoSize);
         infoIconNode.Position = new Vector2(Width - infoSize, Height / 2 - infoSize / 2);
 
         checkmarkIconNode.Size = new Vector2(28, 24);
-        checkmarkIconNode.Position = iconNode.Size - checkmarkIconNode.Size * 0.8f;
+        checkmarkIconNode.Position = iconEndPos - checkmarkIconNode.Size * 0.8f;
 
         itemNameTextNode.Size = new Vector2(Width - iconNode.Width - infoSize - 12.0f, Height);
-        itemNameTextNode.Position = new Vector2(iconNode.Width + 4.0f, 0.0f);
+        itemNameTextNode.Position = new Vector2(iconEndPos.X + 4.0f, 0.0f);
     }
 
     protected override void SetNodeData(DutyLootItemView view) {
@@ -156,10 +158,9 @@ public unsafe class DutyLootNode : ListItemNode<DutyLootItemView>, IListItemNode
 
         iconNode.IconId = item.IconId;
         itemNameTextNode.String = item.Name;
-        iconNode.Count = 1;
         infoIconNode.TextTooltip = string.Join("\n", item.Sources);
         checkmarkIconNode.IsVisible = item.IsUnlocked;
-        iconNode.CollisionNode.ItemTooltip = item.ItemId;
+        CollisionNode.ItemTooltip = item.ItemId;
         favoriteStarNode.IsVisible = view.IsFavorite;
     }
 }

--- a/VanillaPlus/Features/DutyLootPreview/Nodes/DutyLootNode.cs
+++ b/VanillaPlus/Features/DutyLootPreview/Nodes/DutyLootNode.cs
@@ -22,6 +22,7 @@ public unsafe class DutyLootNode : ListItemNode<DutyLootItemView>, IListItemNode
     private readonly SimpleImageNode infoIconNode;
     private readonly SimpleImageNode checkmarkIconNode;
     private readonly ContextMenu contextMenu;
+    private readonly SimpleImageNode armoireIconNode;
 
     public DutyLootNode() {
         contextMenu = new ContextMenu();
@@ -64,6 +65,14 @@ public unsafe class DutyLootNode : ListItemNode<DutyLootItemView>, IListItemNode
             IsVisible = false,
         };
         checkmarkIconNode.AttachNode(this);
+
+        armoireIconNode = new SimpleImageNode {
+            TextureCoordinates = new Vector2(36, 18),
+            TextureSize = new Vector2(18, 18),
+            TexturePath = "ui/uld/ItemDetailPutIn.tex",
+            IsVisible = false,
+        };
+        armoireIconNode.AttachNode(this);
 
         AtkEventListener.Delegates.ReceiveEvent mouseClickCallback = (_, _, _, _, atkEventData) => {
             if (ItemData is null) return;
@@ -151,6 +160,9 @@ public unsafe class DutyLootNode : ListItemNode<DutyLootItemView>, IListItemNode
         checkmarkIconNode.Size = new Vector2(28, 24);
         checkmarkIconNode.Position = iconEndPos - checkmarkIconNode.Size * 0.8f;
 
+        armoireIconNode.Size = new Vector2(18, 18);
+        armoireIconNode.Position = iconEndPos - armoireIconNode.Size - Vector2.One;
+
         itemNameTextNode.Size = new Vector2(Width - iconNode.Width - infoSize - 12.0f, Height);
         itemNameTextNode.Position = new Vector2(iconEndPos.X + 2.0f, 0.0f);
     }
@@ -161,7 +173,18 @@ public unsafe class DutyLootNode : ListItemNode<DutyLootItemView>, IListItemNode
         iconNode.IconId = item.IconId;
         itemNameTextNode.String = item.Name;
         infoIconNode.TextTooltip = string.Join("\n", item.Sources.Distinct());
-        checkmarkIconNode.IsVisible = item.IsUnlocked;
+
+        if (item.IsStorableInCabinet) {
+            checkmarkIconNode.IsVisible = false;
+            armoireIconNode.IsVisible = true;
+            armoireIconNode.TextureCoordinates = new Vector2(36, item.IsStoredInCabinet ? 18 : 0);
+            // armoireIconNode.MultiplyColor = item.IsStoredInCabinet ? Vector3.One : new Vector3(0.8f, 0, 0);
+        }
+        else {
+            checkmarkIconNode.IsVisible = item.IsUnlocked;
+            armoireIconNode.IsVisible = false;
+        }
+
         CollisionNode.ItemTooltip = item.ItemId;
         favoriteStarNode.IsVisible = view.IsFavorite;
     }

--- a/VanillaPlus/Features/DutyLootPreview/Nodes/DutyLootNode.cs
+++ b/VanillaPlus/Features/DutyLootPreview/Nodes/DutyLootNode.cs
@@ -13,7 +13,8 @@ using ContextMenu = KamiToolKit.ContextMenu.ContextMenu;
 namespace VanillaPlus.Features.DutyLootPreview.Nodes;
 
 public unsafe class DutyLootNode : ListItemNode<DutyLootItemView>, IListItemNode {
-    public static float ItemHeight => 36.0f;
+    public static float ItemHeight => 32.0f;
+    public static float IconPadding => 2.0f;
 
     private readonly IconImageNode iconNode;
     private readonly TextNode itemNameTextNode;
@@ -26,7 +27,8 @@ public unsafe class DutyLootNode : ListItemNode<DutyLootItemView>, IListItemNode
         contextMenu = new ContextMenu();
 
         iconNode = new IconImageNode() {
-            TextureSize = new Vector2(32),
+            TextureSize = new Vector2(ItemHeight),
+            WrapMode = WrapMode.Stretch,
             ImageNodeFlags = ImageNodeFlags.AutoFit,
         };
         iconNode.AttachNode(this);
@@ -131,10 +133,9 @@ public unsafe class DutyLootNode : ListItemNode<DutyLootItemView>, IListItemNode
     protected override void OnSizeChanged() {
         base.OnSizeChanged();
 
-        var iconPadding = new Vector2(4);
-        iconNode.Size = new Vector2(Height, Height) - iconPadding * 2;
-        iconNode.Position = new Vector2(iconPadding.X, iconPadding.Y / 2f);
-        var iconEndPos = iconNode.Position + iconNode.Size + iconPadding;
+        iconNode.Size = new Vector2(ItemHeight) - new Vector2(IconPadding * 2);
+        iconNode.Position = new Vector2(IconPadding);
+        var iconEndPos = iconNode.Position + iconNode.Size + new Vector2(IconPadding);
 
         // Scale star proportionally (original: 20x20 star on 44x44 icon)
         var starSize = iconNode.Height * (20f / 44f);
@@ -151,7 +152,7 @@ public unsafe class DutyLootNode : ListItemNode<DutyLootItemView>, IListItemNode
         checkmarkIconNode.Position = iconEndPos - checkmarkIconNode.Size * 0.8f;
 
         itemNameTextNode.Size = new Vector2(Width - iconNode.Width - infoSize - 12.0f, Height);
-        itemNameTextNode.Position = new Vector2(iconEndPos.X + 4.0f, 0.0f);
+        itemNameTextNode.Position = new Vector2(iconEndPos.X + 2.0f, 0.0f);
     }
 
     protected override void SetNodeData(DutyLootItemView view) {

--- a/VanillaPlus/Features/DutyLootPreview/Nodes/DutyLootNode.cs
+++ b/VanillaPlus/Features/DutyLootPreview/Nodes/DutyLootNode.cs
@@ -13,7 +13,7 @@ using ContextMenu = KamiToolKit.ContextMenu.ContextMenu;
 namespace VanillaPlus.Features.DutyLootPreview.Nodes;
 
 public unsafe class DutyLootNode : ListItemNode<DutyLootItemView>, IListItemNode {
-    public static float ItemHeight => 32.0f;
+    public static float ItemHeight => DutyLootPreviewAddon.ItemHeight;
     public static float IconPadding => 2.0f;
 
     private readonly IconImageNode iconNode;

--- a/VanillaPlus/Features/DutyLootPreview/Nodes/DutyLootOpenWindowButtonNode.cs
+++ b/VanillaPlus/Features/DutyLootPreview/Nodes/DutyLootOpenWindowButtonNode.cs
@@ -76,7 +76,7 @@ public class DutyLootOpenWindowButtonNode : SimpleComponentNode {
 
     private void OnDataLoaderStateChanged() {
         var lootData = dataLoader.ActiveDutyLootData;
-        if (dataLoader.IsLoading || lootData == null) {
+        if (dataLoader.IsLoading || lootData == null || lootData.Items.Count == 0) {
             CheckmarkVisible = false;
             return;
         }


### PR DESCRIPTION
Dungeon gear can now be stored in the Armoire, so I thought it would be nice to add support for this.
With this PR, if an item is stored in the armoire, it'll show the checkmark.

I'm super tired and will only draft this for now. Maybe we can gather some feedback on this:

- Do we want to check if an item is present in the inventory/armoury/glamour dresser/retainer? Or just in the armoire? Would probably be nice to know while farming if you're done.
- We might want to add an indicator that a gear item can be stored in the armoire at all. Especially because only Dawntrail dungeon gear is currently able to be stored. But what do we display?
