### PR TITLE
Show checkmark on DutyLootPreview button depending on cabinet status

### DIFF
--- a/VanillaPlus/Features/DutyLootPreview/Nodes/DutyLootOpenWindowButtonNode.cs
+++ b/VanillaPlus/Features/DutyLootPreview/Nodes/DutyLootOpenWindowButtonNode.cs
@@ -81,8 +81,8 @@ public class DutyLootOpenWindowButtonNode : SimpleComponentNode {
             return;
         }
 
-        var unlockableItems = lootData.Items.Where(item => item.IsUnlockable);
-        var allUnlockableItemsUnlocked = unlockableItems.All(item => item.IsUnlocked);
+        var unlockableItems = lootData.Items.Where(item => item.IsUnlockable || item.IsStorableInCabinet);
+        var allUnlockableItemsUnlocked = unlockableItems.All(item => item.IsUnlocked || item.IsStoredInCabinet);
         CheckmarkVisible = allUnlockableItemsUnlocked;
     }
 }


### PR DESCRIPTION
Not worth mentioning in the changelog, really.
I just forgot to add this in my PR, even though I talked about it. #LastMinuteRefactor