### PR TITLE
Add Borderless Cutscenes

### DIFF
--- a/VanillaPlus/Features/BorderlessCutscenes/BorderlessCutscenes.cs
+++ b/VanillaPlus/Features/BorderlessCutscenes/BorderlessCutscenes.cs
@@ -1,0 +1,35 @@
+﻿using Dalamud.Utility.Signatures;
+using VanillaPlus.Classes;
+using VanillaPlus.Enums;
+
+namespace VanillaPlus.Features.BorderlessCutscenes;
+
+public class BorderlessCutscenes : GameModification {
+    public override ModificationInfo ModificationInfo => new() {
+        DisplayName = "Borderless Cutscenes",
+        Description = "Removes the letterboxing in cutscenes when using ultrawide displays.",
+        Type = ModificationType.GameBehavior,
+        Authors = [ "goat", "Maple", "MidoriKami" ],
+    };
+
+    [Signature("01 0F 84 ?? ?? ?? ?? 48 8B 0D ?? ?? ?? ?? 0F 57 D2 F3 0F 10 1D ?? ?? ?? ?? 0F 57 C9 48 89 B4 24")]
+    private nint? memoryAddress;
+
+    private MemoryReplacement? jumpPatch;
+
+    public override void OnEnable() {
+        Services.GameInteropProvider.InitializeFromAttributes(this);
+        
+        if (memoryAddress is { } address && memoryAddress != nint.Zero) {
+            jumpPatch = new MemoryReplacement(address, [0x00]);
+            jumpPatch.Enable();
+        }
+    }
+
+    public override void OnDisable() {
+        jumpPatch?.Dispose();
+        jumpPatch = null;
+        
+        memoryAddress = null;
+    }
+}


### PR DESCRIPTION
With permission from Maple

"Hi, I think that's a good idea actually, it makes sense to have it on VanillaPlus.

I'm cool with you adding it, and I don't mind continuing to update it for people who prefer or already use the standalone version, I was planning to update the plugin to 7.5, and usually I'm pretty quick to do it, but this patch released while I'm in the middle of a trip, so I didn't get around to it yet since I don't have a xiv dev environment on my laptop."