### PR TITLE
Fix Duty Loot Preview interactions with high-end duties

### DIFF
--- a/VanillaPlus/Features/DutyLootPreview/Data/DutyLootDataLoader.cs
+++ b/VanillaPlus/Features/DutyLootPreview/Data/DutyLootDataLoader.cs
@@ -25,6 +25,7 @@ public class DutyLootDataLoader : IDisposable {
 
     private readonly DutyLootDataCache dutyLootDataCache = new();
     private AddonController<AddonContentsFinder>? contentsFinder;
+    private AddonController<AddonRaidFinder>? raidFinder;
 
     public unsafe void Enable() {
         Services.ClientState.TerritoryChanged += OnTerritoryChanged;
@@ -38,6 +39,14 @@ public class DutyLootDataLoader : IDisposable {
         };
         contentsFinder.Enable();
 
+        raidFinder = new AddonController<AddonRaidFinder> {
+            AddonName = "RaidFinder",
+            OnSetup = OnRaidFinderChanged,
+            OnRefresh = OnRaidFinderChanged,
+            OnFinalize = OnRaidFinderChanged,
+        };
+        raidFinder.Enable();
+
         dutyLootDataCache.OnChanged += OnCacheChanged;
 
         RefreshActiveDuty();
@@ -46,6 +55,9 @@ public class DutyLootDataLoader : IDisposable {
     public void Dispose() {
         contentsFinder?.Dispose();
         contentsFinder = null;
+
+        raidFinder?.Dispose();
+        raidFinder = null;
 
         Services.ClientState.TerritoryChanged -= OnTerritoryChanged;
         Services.GameGui.AgentUpdate -= OnAgentUpdate;
@@ -61,10 +73,21 @@ public class DutyLootDataLoader : IDisposable {
             return currentDutyId;
         }
 
-        // Priority 2: Viewing a specific duty in ContentsFinder
-        var agent = AgentContentsFinder.Instance();
-        if (agent->IsAddonShown() && IsSupportedContent(agent->SelectedDuty)) {
-            return agent->SelectedDuty.Id;
+        // Priority 2: Viewing a specific duty in ContentsFinder or RaidFinder
+        var agentContentsFinder = AgentContentsFinder.Instance();
+        if (agentContentsFinder->IsAddonShown() && IsSupportedContent(agentContentsFinder->SelectedDuty)) {
+            return agentContentsFinder->SelectedDuty.Id;
+        }
+
+        var agentRaidFinder = AgentRaidFinder.Instance();
+        if (agentRaidFinder->IsAddonShown()) {
+            var selectedTab = (int)agentRaidFinder->SelectedTab;
+            var selectedEntry = (int)agentRaidFinder->SelectedEntry;
+            var raidId = agentRaidFinder->Tabs[selectedTab].Entries[selectedEntry].ContentFinderConditionId;
+
+            if (IsSupportedContent(new ContentsId { ContentType = ContentsType.Regular, Id = raidId })) {
+                return raidId;
+            }
         }
 
         return null;
@@ -101,6 +124,7 @@ public class DutyLootDataLoader : IDisposable {
     private void OnCacheChanged() => OnChanged?.Invoke();
 
     private unsafe void OnContentsFinderChanged(AddonContentsFinder* addon) => RefreshActiveDuty();
+    private unsafe void OnRaidFinderChanged(AddonRaidFinder* addon) => RefreshActiveDuty();
 
     private void OnTerritoryChanged(uint u) => RefreshActiveDuty();
 

--- a/VanillaPlus/Features/DutyLootPreview/DutyLootJournalUiController.cs
+++ b/VanillaPlus/Features/DutyLootPreview/DutyLootJournalUiController.cs
@@ -49,7 +49,7 @@ public unsafe class DutyLootJournalUiController {
         // Only attach if parent is the Duty Finder
         if (addon->ParentId is not 0) {
             var parentAddon = RaptureAtkUnitManager.Instance()->GetAddonById(addon->ParentId);
-            if (parentAddon is null || parentAddon->NameString != "ContentsFinder") {
+            if (parentAddon is null || (parentAddon->NameString != "ContentsFinder" && parentAddon->NameString != "RaidFinder")) {
                 return;
             }
         }

--- a/VanillaPlus/Features/DutyLootPreview/DutyLootJournalUiController.cs
+++ b/VanillaPlus/Features/DutyLootPreview/DutyLootJournalUiController.cs
@@ -14,6 +14,7 @@ namespace VanillaPlus.Features.DutyLootPreview;
 public unsafe class DutyLootJournalUiController {
     private AddonController<AddonJournalDetail>? journalDetail;
     private DutyLootOpenWindowButtonNode? lootButtonNode;
+    private ushort attachedAddonId;
 
     public required DutyLootDataLoader DataLoader;
 
@@ -22,7 +23,7 @@ public unsafe class DutyLootJournalUiController {
     public void OnEnable() {
         journalDetail = new AddonController<AddonJournalDetail> {
             AddonName = "JournalDetail",
-            OnSetup = SetupJounralDetail,
+            OnSetup = SetupJournalDetail,
             OnFinalize = FinalizeJournalDetail,
             OnRefresh = RefreshJournalDetail,
         };
@@ -38,25 +39,38 @@ public unsafe class DutyLootJournalUiController {
         journalDetail = null;
     }
 
-    private void SetupJounralDetail(AddonJournalDetail* addon) {
+    private void SetupJournalDetail(AddonJournalDetail* addon) {
         var dutyTitleNode = addon->GetNodeById(37);
         if (dutyTitleNode is null) return;
 
         var existing = addon->DutyNameTextNode; // ID: 38
         if (existing is null) return;
 
+        // Only attach if parent is the Duty Finder
+        if (addon->ParentId is not 0) {
+            var parentAddon = RaptureAtkUnitManager.Instance()->GetAddonById(addon->ParentId);
+            if (parentAddon is null || parentAddon->NameString != "ContentsFinder") {
+                return;
+            }
+        }
+
+        if (journalDetail is not null) {
+            CleanupAttached();
+        }
+
         lootButtonNode = new DutyLootOpenWindowButtonNode(DataLoader) {
             Position = new Vector2(420.0f, 68.0f),
             Size = new Vector2(32.0f, 32.0f),
             TextTooltip = Strings.DutyLoot_Tooltip_JournalButton,
             OnClick = () => OnButtonClicked?.Invoke(),
-            IsVisible = ShouldShow(addon),
+            IsVisible = ShouldShow(),
         };
         lootButtonNode.AttachNode(dutyTitleNode, NodePosition.AfterTarget);
+        attachedAddonId = addon->Id;
     }
 
     private void RefreshJournalDetail(AddonJournalDetail* addon)
-        => lootButtonNode?.IsVisible = ShouldShow(addon);
+        => lootButtonNode?.IsVisible = ShouldShow();
 
     private void OnDataChanged() {
         if (lootButtonNode == null) return;
@@ -64,24 +78,23 @@ public unsafe class DutyLootJournalUiController {
         var addon = Services.GameGui.GetAddonByName<AddonJournalDetail>("JournalDetail");
         if (addon == null) return;
 
-        lootButtonNode.IsVisible = ShouldShow(addon);
+        lootButtonNode.IsVisible = ShouldShow();
     }
 
-    private bool ShouldShow(AddonJournalDetail* addon) {
-        // Only show if parent is the Duty Finder
-        if (addon->ParentId is not 0) {
-            var parentAddon = RaptureAtkUnitManager.Instance()->GetAddonById(addon->ParentId);
-            if (parentAddon is null || parentAddon->NameString != "ContentsFinder") {
-                return false;
-            }
-        }
-
+    private bool ShouldShow() {
         var lootData = DataLoader.ActiveDutyLootData;
         return lootData is not null || DataLoader.IsLoading;
     }
 
     private void FinalizeJournalDetail(AddonJournalDetail* addon) {
+        if (addon->Id != attachedAddonId) return;
+
+        CleanupAttached();
+    }
+
+    private void CleanupAttached() {
         lootButtonNode?.Dispose();
         lootButtonNode = null;
+        attachedAddonId = 0;
     }
 }


### PR DESCRIPTION
The fix fixes the following issues:
1. When switching from "Regular Duty" to "High-end Duty" tab and back, the button would no longer appear.
2. When the journal (quests) was opened, the button would disappear from the duty finder.

The main issue for the first point was that the two tabs are different addons and the game finalizes the JournalDetail addon from the previous tab AFTER the setup of the new tab.
This means the plugin would attach a second node without cleaning out the first and it would then instantly clean the second one.

The button seems to work out of the box for high-end duties now that the agent is in CS (thanks @Haselnussbomber!).
<img width="1475" height="736" alt="image" src="https://github.com/user-attachments/assets/fedb791c-19ec-44f8-b4db-ca1d0b6c6859" />

The only small issue is that the loot is not updating properly for FRU due to a size issue in CS that will be fixed (cf. https://github.com/aers/FFXIVClientStructs/pull/1838 ).

Tagging @grittyfrog as well as I see this is your modification :).