### PR TITLE
Localization update for 1.4.0.2

### DIFF
--- a/VanillaPlus/Enums/ModificationType.cs
+++ b/VanillaPlus/Enums/ModificationType.cs
@@ -42,6 +42,6 @@ public enum ModificationType {
     /// <summary>
     /// Seasonal modules that may be available only for a limited time
     /// </summary>
-    [Description("Seasonal")]
+    [Description(nameof(Strings.ModificationType_Seasonal))]
     Seasonal,
 }

--- a/VanillaPlus/Features/BetterTeleportWindow/BetterTeleportWindow.cs
+++ b/VanillaPlus/Features/BetterTeleportWindow/BetterTeleportWindow.cs
@@ -8,8 +8,8 @@ namespace VanillaPlus.Features.BetterTeleportWindow;
 
 public class BetterTeleportWindow : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Better Teleport Window",
-        Description = "Replaces the games Teleport window with a better custom made version.",
+        DisplayName = Strings.ModificationDisplay_BetterTeleportWindow,
+        Description = Strings.ModificationDescription_BetterTeleportWindow,
         Type = ModificationType.NewWindow,
         Authors = [ "MidoriKami" ],
     };
@@ -28,7 +28,7 @@ public class BetterTeleportWindow : GameModification {
             AddonName = "Teleport",
             CreateNativeAddonFunction = () => CustomTeleportAddon = new TeleportAddon(Config) {
                 InternalName = "Teleport",
-                Title = "Teleport",
+                Title = Strings.BetterTeleportWindow_WindowTitle,
                 Size = new Vector2(700.0f, 600.0f),
             },
         };

--- a/VanillaPlus/Features/BetterTeleportWindow/ListMode.cs
+++ b/VanillaPlus/Features/BetterTeleportWindow/ListMode.cs
@@ -4,17 +4,17 @@ namespace VanillaPlus.Features.BetterTeleportWindow;
 
 public enum ListMode {
 
-    [Description("All")]
+    [Description("BetterTeleportWindow_ModeAll")]
     All,
 
     // Not implemented currently, but maybe planned in the future.
-    [Description("History")]
+    [Description("BetterTeleportWindow_ModeHistory")]
     History,
 
-    [Description("Favorites")]
+    [Description("BetterTeleportWindow_ModeFavorites")]
     Favorites,
 
-    [Description("Cities")]
+    [Description("BetterTeleportWindow_ModeCities")]
     Cities,
 
     // This is a category not a specific entry, it doesn't need a description.

--- a/VanillaPlus/Features/BetterTeleportWindow/TeleportAddon.cs
+++ b/VanillaPlus/Features/BetterTeleportWindow/TeleportAddon.cs
@@ -82,7 +82,7 @@ public class TeleportAddon(BetterTeleportWindowConfig config) : NativeAddon {
                                 new CheckboxNode {
                                     Size = new Vector2(28.0f, 28.0f),
                                     IsChecked = config.AutoFocusSearch,
-                                    TextTooltip = "Toggle Auto Focus Searchbar",
+                                    TextTooltip = Strings.BetterTeleportWindow_TooltipAutoFocus,
                                     OnClick = newValue => {
                                         config.AutoFocusSearch = newValue;
                                         Task.Run(config.Save);
@@ -94,7 +94,7 @@ public class TeleportAddon(BetterTeleportWindowConfig config) : NativeAddon {
                             Height = ContentSize.Y - 28.0f - itemSpacing * 2.0f,
                             ItemSpacing = itemSpacing * 1.5f,
                             OptionsList = Services.AetheryteList.ToList(),
-                            NoResultsString = "No Aetherytes Match Search",
+                            NoResultsString = Strings.BetterTeleportWindow_NoResults,
                         },
                     ],
                 },

--- a/VanillaPlus/Features/BetterTeleportWindow/TeleportListItemNode.cs
+++ b/VanillaPlus/Features/BetterTeleportWindow/TeleportListItemNode.cs
@@ -116,7 +116,7 @@ public unsafe class TeleportListItemNode : ListItemNode<IAetheryteEntry>, IListI
                 OnClick = () => {
                     renameAddon?.Dispose();
                     renameAddon = new RenameAddon {
-                        Title = "Rename Teleport",
+                        Title = Strings.BetterTeleportWindow_RenameTitle,
                         InternalName = "RenameTeleport",
                         AutoSelectAll = true,
                         DefaultString = GetCustomName(ItemData),

--- a/VanillaPlus/Features/BorderlessCutscenes/BorderlessCutscenes.cs
+++ b/VanillaPlus/Features/BorderlessCutscenes/BorderlessCutscenes.cs
@@ -7,8 +7,8 @@ namespace VanillaPlus.Features.BorderlessCutscenes;
 
 public class BorderlessCutscenes : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Borderless Cutscenes",
-        Description = "Removes the letterboxing in cutscenes when using ultrawide displays.",
+        DisplayName = Strings.ModificationDisplay_BorderlessCutscenes,
+        Description = Strings.ModificationDescription_BorderlessCutscenes,
         Type = ModificationType.GameBehavior,
         Authors = ["goat", "Maple", "MidoriKami"],
         CompatibilityModule = new PluginCompatibilityModule("Dalamud.FullscreenCutscenes"),

--- a/VanillaPlus/Features/DutyPortalNameplateOffset/DutyPortalNameplateOffset.cs
+++ b/VanillaPlus/Features/DutyPortalNameplateOffset/DutyPortalNameplateOffset.cs
@@ -10,8 +10,8 @@ namespace VanillaPlus.Features.DutyPortalNameplateOffset;
 
 public class DutyPortalNameplateOffset : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Raise Duty Portal Nameplates",
-        Description = "Raises certain duty-related interaction nameplates to improve visibility when crowded by player nameplates.",
+        DisplayName = Strings.ModificationDisplay_DutyPortalNameplateOffset,
+        Description = Strings.ModificationDescription_DutyPortalNameplateOffset,
         Type = ModificationType.UserInterface,
         Authors = ["Epinephren"],
     };

--- a/VanillaPlus/Features/SuppressSharedBoards/SuppressSharedBoards.cs
+++ b/VanillaPlus/Features/SuppressSharedBoards/SuppressSharedBoards.cs
@@ -8,8 +8,8 @@ namespace VanillaPlus.Features.SuppressSharedBoards;
 
 public unsafe class SuppressSharedBoards : GameModification {
     public override ModificationInfo ModificationInfo => new() {
-        DisplayName = "Suppress Shared Strategy Boards",
-        Description = "Completely suppresses any shared Strategy Board.",
+        DisplayName = Strings.ModificationDisplay_SuppressSharedBoards,
+        Description = Strings.ModificationDescription_SuppressSharedBoards,
         Type = ModificationType.GameBehavior,
         Authors = ["Treezy"],
     };

--- a/VanillaPlus/Native/Addons/AddonConfigAddon.cs
+++ b/VanillaPlus/Native/Addons/AddonConfigAddon.cs
@@ -151,14 +151,14 @@ public class AddonConfigAddon : NativeAddon {
         var additionalOptionsTextNode = new UnderlinedTextNode {
             Size = new Vector2(ContentSize.X, 28.0f),
             Position = new Vector2(ContentStartPosition.X, editNoteTextNode.Bounds.Bottom),
-            String = "Additional Options",
+            String = Strings.AddonConfig_AdditionalOptions,
         };
         additionalOptionsTextNode.AttachNode(this);
 
         new CheckboxNode {
             Position = new Vector2(ContentStartPosition.X, additionalOptionsTextNode.Bounds.Bottom),
             Size = new Vector2(ContentSize.X, 24.0f),
-            String = "Disable Keybind in Combat",
+            String = Strings.AddonConfig_DisableKeybindInCombat,
             IsChecked = AddonConfig.DisableInCombat,
             OnClick = newValue => {
                 AddonConfig.DisableInCombat = newValue;

--- a/VanillaPlus/Native/Addons/ModificationBrowserAddon.cs
+++ b/VanillaPlus/Native/Addons/ModificationBrowserAddon.cs
@@ -42,7 +42,7 @@ public class ModificationBrowserAddon : NativeAddon {
                     InitialNodes = [
                         new CheckboxNode { // Persist Search Button
                             Width = 28.0f,
-                            TextTooltip = "Persist Search Between Sessions",
+                            TextTooltip = Strings.ModificationBrowser_PersistSearchTooltip,
                             IsChecked = System.SystemConfig.PersistSearch,
                             OnClick = value => {
                                 System.SystemConfig.PersistSearch = value;
@@ -51,7 +51,7 @@ public class ModificationBrowserAddon : NativeAddon {
                         },
                         textInputNode = new TextInputNode { // Search Input
                             Width = ContentSize.X - 28.0f,
-                            PlaceholderString = "Search . . .",
+                            PlaceholderString = Strings.SearchPlaceholder,
                             AutoSelectAll = true,
                             String = System.SystemConfig.PersistSearch ? System.SystemConfig.CurrentSearch : string.Empty,
                             OnInputReceived = OnSearchInputReceived,
@@ -77,9 +77,9 @@ public class ModificationBrowserAddon : NativeAddon {
                                     NavUp = 1,
                                     NavDown = 6,
                                     InitialEntries = [
-                                        new TabBarEntry{ Label = "All", OnClick = () => SwitchTab(BrowserSelectedTab.All) },
-                                        new TabBarEntry{ Label = "Enable", OnClick = () => SwitchTab(BrowserSelectedTab.Enabled) },
-                                        new TabBarEntry{ Label = "Disable", OnClick = () => SwitchTab(BrowserSelectedTab.Disabled) },
+                                        new TabBarEntry{ Label = Strings.ModificationBrowser_TabAll, OnClick = () => SwitchTab(BrowserSelectedTab.All) },
+                                        new TabBarEntry{ Label = Strings.ModificationBrowser_TabEnabled, OnClick = () => SwitchTab(BrowserSelectedTab.Enabled) },
+                                        new TabBarEntry{ Label = Strings.ModificationBrowser_TabDisabled, OnClick = () => SwitchTab(BrowserSelectedTab.Disabled) },
                                     ],
                                 },
                                 new TabBarNode {
@@ -88,10 +88,10 @@ public class ModificationBrowserAddon : NativeAddon {
                                     NavUp = 3,
                                     NavDown = 10,
                                     InitialEntries = [
-                                        new TabBarEntry{ Label = "All", OnClick = () => SwitchCategory(BrowserSelectedCategory.All) },
-                                        new TabBarEntry{ Label = "Window", OnClick = () => SwitchCategory(BrowserSelectedCategory.Window), Tooltip = "New Windows or Overlays" },
-                                        new TabBarEntry{ Label = "UI", OnClick = () => SwitchCategory(BrowserSelectedCategory.Ui), Tooltip = "Modifies existing game UI" },
-                                        new TabBarEntry{ Label = "Behavior", OnClick = () => SwitchCategory(BrowserSelectedCategory.Behavior), Tooltip = "Changes how parts of the game work" },
+                                        new TabBarEntry{ Label = Strings.ModificationBrowser_TabAll, OnClick = () => SwitchCategory(BrowserSelectedCategory.All) },
+                                        new TabBarEntry{ Label = Strings.ModificationBrowser_CategoryWindow, OnClick = () => SwitchCategory(BrowserSelectedCategory.Window), Tooltip = Strings.ModificationBrowser_CategoryWindowTooltip },
+                                        new TabBarEntry{ Label = Strings.ModificationBrowser_CategoryUi, OnClick = () => SwitchCategory(BrowserSelectedCategory.Ui), Tooltip = Strings.ModificationBrowser_CategoryUiTooltip },
+                                        new TabBarEntry{ Label = Strings.ModificationBrowser_CategoryBehavior, OnClick = () => SwitchCategory(BrowserSelectedCategory.Behavior), Tooltip = Strings.ModificationBrowser_CategoryBehaviorTooltip },
                                     ],
                                 },
                                 new ResNode { Height = 12.0f },
@@ -101,7 +101,7 @@ public class ModificationBrowserAddon : NativeAddon {
                                     NavUp = 6,
                                     NavRight = 100,
                                     OptionsList = GetModifications(),
-                                    NoResultsString = "No Results Match Search",
+                                    NoResultsString = Strings.ModificationBrowser_NoResults,
                                     OnItemSelected = selectedItem
                                         => modificationInfoNode?.SetDisplayedGameModification(selectedItem),
                                 },

--- a/VanillaPlus/Native/Addons/SeasonEventAddon.cs
+++ b/VanillaPlus/Native/Addons/SeasonEventAddon.cs
@@ -54,21 +54,20 @@ public class SeasonEventAddon : NativeAddon {
             InitialNodes = [
                 new TextNode {
                     Height = 64.0f,
-                    String = "Seasonal Event",
+                    String = Strings.SeasonEventNotice_Heading,
                     FontSize = 32,
                     AlignmentType = AlignmentType.Center,
                 },
                 new TextNode {
                     Height = 32.0f,
-                    String = "It's that time of year again! There is a seasonal event happening right now!\n" +
-                             "To join in the festivities, check out the Seasonal section in VanillaPlus!",
+                    String = Strings.SeasonEventNotice_Body,
                     LineSpacing = 20,
                     AlignmentType = AlignmentType.Center,
                     TextFlags = TextFlags.WordWrap | TextFlags.MultiLine,
                 },
                 new CategoryTextNode {
                     Height = 32.0f,
-                    String = "This will only show once on each day a seasonal event occurs",
+                    String = Strings.SeasonEventNotice_DailyHint,
                     AlignmentType = AlignmentType.Bottom,
                 },
                 new ResNode { Height = 32.0f },
@@ -78,12 +77,12 @@ public class SeasonEventAddon : NativeAddon {
                     InitialNodes = [
                         new TextButtonNode {
                             Width = 200.0f,
-                            String = "Go Away",
+                            String = Strings.SeasonEventNotice_ButtonDismiss,
                             OnClick = Close,
                         },
                         new TextButtonNode {
                             Width = 200.0f,
-                            String = "Open VanillaPlus",
+                            String = Strings.SeasonEventNotice_ButtonOpen,
                             OnClick = System.ModificationBrowserAddon.Toggle,
                         },
                     ],

--- a/VanillaPlus/Resources/Strings.Designer.cs
+++ b/VanillaPlus/Resources/Strings.Designer.cs
@@ -4530,5 +4530,185 @@ namespace Resources {
                 return ResourceManager.GetString("ModificationDescription_DutyPortalNameplateOffset", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to All.
+        /// </summary>
+        internal static string ModificationBrowser_TabAll {
+            get {
+                return ResourceManager.GetString("ModificationBrowser_TabAll", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enable.
+        /// </summary>
+        internal static string ModificationBrowser_TabEnabled {
+            get {
+                return ResourceManager.GetString("ModificationBrowser_TabEnabled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Disable.
+        /// </summary>
+        internal static string ModificationBrowser_TabDisabled {
+            get {
+                return ResourceManager.GetString("ModificationBrowser_TabDisabled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Window.
+        /// </summary>
+        internal static string ModificationBrowser_CategoryWindow {
+            get {
+                return ResourceManager.GetString("ModificationBrowser_CategoryWindow", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to New Windows or Overlays.
+        /// </summary>
+        internal static string ModificationBrowser_CategoryWindowTooltip {
+            get {
+                return ResourceManager.GetString("ModificationBrowser_CategoryWindowTooltip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to UI.
+        /// </summary>
+        internal static string ModificationBrowser_CategoryUi {
+            get {
+                return ResourceManager.GetString("ModificationBrowser_CategoryUi", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Modifies existing game UI.
+        /// </summary>
+        internal static string ModificationBrowser_CategoryUiTooltip {
+            get {
+                return ResourceManager.GetString("ModificationBrowser_CategoryUiTooltip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Behavior.
+        /// </summary>
+        internal static string ModificationBrowser_CategoryBehavior {
+            get {
+                return ResourceManager.GetString("ModificationBrowser_CategoryBehavior", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Changes how parts of the game work.
+        /// </summary>
+        internal static string ModificationBrowser_CategoryBehaviorTooltip {
+            get {
+                return ResourceManager.GetString("ModificationBrowser_CategoryBehaviorTooltip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Persist Search Between Sessions.
+        /// </summary>
+        internal static string ModificationBrowser_PersistSearchTooltip {
+            get {
+                return ResourceManager.GetString("ModificationBrowser_PersistSearchTooltip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No Results Match Search.
+        /// </summary>
+        internal static string ModificationBrowser_NoResults {
+            get {
+                return ResourceManager.GetString("ModificationBrowser_NoResults", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Seasonal.
+        /// </summary>
+        internal static string ModificationType_Seasonal {
+            get {
+                return ResourceManager.GetString("ModificationType_Seasonal", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Seasonal Event Notice.
+        /// </summary>
+        internal static string SeasonEventNotice_Title {
+            get {
+                return ResourceManager.GetString("SeasonEventNotice_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Seasonal Event.
+        /// </summary>
+        internal static string SeasonEventNotice_Heading {
+            get {
+                return ResourceManager.GetString("SeasonEventNotice_Heading", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to It's that time of year again! There is a seasonal event happening right now!.
+        /// </summary>
+        internal static string SeasonEventNotice_Body {
+            get {
+                return ResourceManager.GetString("SeasonEventNotice_Body", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This will only show once on each day a seasonal event occurs.
+        /// </summary>
+        internal static string SeasonEventNotice_DailyHint {
+            get {
+                return ResourceManager.GetString("SeasonEventNotice_DailyHint", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Go Away.
+        /// </summary>
+        internal static string SeasonEventNotice_ButtonDismiss {
+            get {
+                return ResourceManager.GetString("SeasonEventNotice_ButtonDismiss", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Open VanillaPlus.
+        /// </summary>
+        internal static string SeasonEventNotice_ButtonOpen {
+            get {
+                return ResourceManager.GetString("SeasonEventNotice_ButtonOpen", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Additional Options.
+        /// </summary>
+        internal static string AddonConfig_AdditionalOptions {
+            get {
+                return ResourceManager.GetString("AddonConfig_AdditionalOptions", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Disable Keybind in Combat.
+        /// </summary>
+        internal static string AddonConfig_DisableKeybindInCombat {
+            get {
+                return ResourceManager.GetString("AddonConfig_DisableKeybindInCombat", resourceCulture);
+            }
+        }
     }
 }

--- a/VanillaPlus/Resources/Strings.Designer.cs
+++ b/VanillaPlus/Resources/Strings.Designer.cs
@@ -4386,5 +4386,149 @@ namespace Resources {
                 return ResourceManager.GetString("WondrousTailsProbabilities_ShuffleAverageLabel", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Better Teleport Window.
+        /// </summary>
+        internal static string ModificationDisplay_BetterTeleportWindow {
+            get {
+                return ResourceManager.GetString("ModificationDisplay_BetterTeleportWindow", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Replaces the games Teleport window with a better custom made version..
+        /// </summary>
+        internal static string ModificationDescription_BetterTeleportWindow {
+            get {
+                return ResourceManager.GetString("ModificationDescription_BetterTeleportWindow", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Teleport.
+        /// </summary>
+        internal static string BetterTeleportWindow_WindowTitle {
+            get {
+                return ResourceManager.GetString("BetterTeleportWindow_WindowTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rename Teleport.
+        /// </summary>
+        internal static string BetterTeleportWindow_RenameTitle {
+            get {
+                return ResourceManager.GetString("BetterTeleportWindow_RenameTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Toggle Auto Focus Searchbar.
+        /// </summary>
+        internal static string BetterTeleportWindow_TooltipAutoFocus {
+            get {
+                return ResourceManager.GetString("BetterTeleportWindow_TooltipAutoFocus", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No Aetherytes Match Search.
+        /// </summary>
+        internal static string BetterTeleportWindow_NoResults {
+            get {
+                return ResourceManager.GetString("BetterTeleportWindow_NoResults", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to All.
+        /// </summary>
+        internal static string BetterTeleportWindow_ModeAll {
+            get {
+                return ResourceManager.GetString("BetterTeleportWindow_ModeAll", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to History.
+        /// </summary>
+        internal static string BetterTeleportWindow_ModeHistory {
+            get {
+                return ResourceManager.GetString("BetterTeleportWindow_ModeHistory", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Favorites.
+        /// </summary>
+        internal static string BetterTeleportWindow_ModeFavorites {
+            get {
+                return ResourceManager.GetString("BetterTeleportWindow_ModeFavorites", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cities.
+        /// </summary>
+        internal static string BetterTeleportWindow_ModeCities {
+            get {
+                return ResourceManager.GetString("BetterTeleportWindow_ModeCities", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Borderless Cutscenes.
+        /// </summary>
+        internal static string ModificationDisplay_BorderlessCutscenes {
+            get {
+                return ResourceManager.GetString("ModificationDisplay_BorderlessCutscenes", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Removes the letterboxing in cutscenes when using ultrawide displays..
+        /// </summary>
+        internal static string ModificationDescription_BorderlessCutscenes {
+            get {
+                return ResourceManager.GetString("ModificationDescription_BorderlessCutscenes", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Suppress Shared Strategy Boards.
+        /// </summary>
+        internal static string ModificationDisplay_SuppressSharedBoards {
+            get {
+                return ResourceManager.GetString("ModificationDisplay_SuppressSharedBoards", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Completely suppresses any shared Strategy Board..
+        /// </summary>
+        internal static string ModificationDescription_SuppressSharedBoards {
+            get {
+                return ResourceManager.GetString("ModificationDescription_SuppressSharedBoards", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Raise Duty Portal Nameplates.
+        /// </summary>
+        internal static string ModificationDisplay_DutyPortalNameplateOffset {
+            get {
+                return ResourceManager.GetString("ModificationDisplay_DutyPortalNameplateOffset", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Raises certain duty-related interaction nameplates to improve visibility when crowded by player nameplates..
+        /// </summary>
+        internal static string ModificationDescription_DutyPortalNameplateOffset {
+            get {
+                return ResourceManager.GetString("ModificationDescription_DutyPortalNameplateOffset", resourceCulture);
+            }
+        }
     }
 }

--- a/VanillaPlus/Resources/Strings.resx
+++ b/VanillaPlus/Resources/Strings.resx
@@ -1583,4 +1583,52 @@ This game modification fixes it by always triggering the normal mouse click in a
   <data name="ResetDummyEnmity_ResetEnmityToolTip" xml:space="preserve">
       <value>[VanillaPlus] Reset Enmity</value>
   </data>
+  <data name="ModificationDisplay_BetterTeleportWindow" xml:space="preserve">
+    <value>Better Teleport Window</value>
+  </data>
+  <data name="ModificationDescription_BetterTeleportWindow" xml:space="preserve">
+    <value>Replaces the games Teleport window with a better custom made version.</value>
+  </data>
+  <data name="BetterTeleportWindow_WindowTitle" xml:space="preserve">
+    <value>Teleport</value>
+  </data>
+  <data name="BetterTeleportWindow_RenameTitle" xml:space="preserve">
+    <value>Rename Teleport</value>
+  </data>
+  <data name="BetterTeleportWindow_TooltipAutoFocus" xml:space="preserve">
+    <value>Toggle Auto Focus Searchbar</value>
+  </data>
+  <data name="BetterTeleportWindow_NoResults" xml:space="preserve">
+    <value>No Aetherytes Match Search</value>
+  </data>
+  <data name="BetterTeleportWindow_ModeAll" xml:space="preserve">
+    <value>All</value>
+  </data>
+  <data name="BetterTeleportWindow_ModeHistory" xml:space="preserve">
+    <value>History</value>
+  </data>
+  <data name="BetterTeleportWindow_ModeFavorites" xml:space="preserve">
+    <value>Favorites</value>
+  </data>
+  <data name="BetterTeleportWindow_ModeCities" xml:space="preserve">
+    <value>Cities</value>
+  </data>
+  <data name="ModificationDisplay_BorderlessCutscenes" xml:space="preserve">
+    <value>Borderless Cutscenes</value>
+  </data>
+  <data name="ModificationDescription_BorderlessCutscenes" xml:space="preserve">
+    <value>Removes the letterboxing in cutscenes when using ultrawide displays.</value>
+  </data>
+  <data name="ModificationDisplay_SuppressSharedBoards" xml:space="preserve">
+    <value>Suppress Shared Strategy Boards</value>
+  </data>
+  <data name="ModificationDescription_SuppressSharedBoards" xml:space="preserve">
+    <value>Completely suppresses any shared Strategy Board.</value>
+  </data>
+  <data name="ModificationDisplay_DutyPortalNameplateOffset" xml:space="preserve">
+    <value>Raise Duty Portal Nameplates</value>
+  </data>
+  <data name="ModificationDescription_DutyPortalNameplateOffset" xml:space="preserve">
+    <value>Raises certain duty-related interaction nameplates to improve visibility when crowded by player nameplates.</value>
+  </data>
 </root>

--- a/VanillaPlus/Resources/Strings.resx
+++ b/VanillaPlus/Resources/Strings.resx
@@ -1631,4 +1631,65 @@ This game modification fixes it by always triggering the normal mouse click in a
   <data name="ModificationDescription_DutyPortalNameplateOffset" xml:space="preserve">
     <value>Raises certain duty-related interaction nameplates to improve visibility when crowded by player nameplates.</value>
   </data>
+  <data name="ModificationBrowser_TabAll" xml:space="preserve">
+    <value>All</value>
+  </data>
+  <data name="ModificationBrowser_TabEnabled" xml:space="preserve">
+    <value>Enable</value>
+  </data>
+  <data name="ModificationBrowser_TabDisabled" xml:space="preserve">
+    <value>Disable</value>
+  </data>
+  <data name="ModificationBrowser_CategoryWindow" xml:space="preserve">
+    <value>Window</value>
+  </data>
+  <data name="ModificationBrowser_CategoryWindowTooltip" xml:space="preserve">
+    <value>New Windows or Overlays</value>
+  </data>
+  <data name="ModificationBrowser_CategoryUi" xml:space="preserve">
+    <value>UI</value>
+  </data>
+  <data name="ModificationBrowser_CategoryUiTooltip" xml:space="preserve">
+    <value>Modifies existing game UI</value>
+  </data>
+  <data name="ModificationBrowser_CategoryBehavior" xml:space="preserve">
+    <value>Behavior</value>
+  </data>
+  <data name="ModificationBrowser_CategoryBehaviorTooltip" xml:space="preserve">
+    <value>Changes how parts of the game work</value>
+  </data>
+  <data name="ModificationBrowser_PersistSearchTooltip" xml:space="preserve">
+    <value>Persist Search Between Sessions</value>
+  </data>
+  <data name="ModificationBrowser_NoResults" xml:space="preserve">
+    <value>No Results Match Search</value>
+  </data>
+  <data name="ModificationType_Seasonal" xml:space="preserve">
+    <value>Seasonal</value>
+  </data>
+  <data name="SeasonEventNotice_Title" xml:space="preserve">
+    <value>Seasonal Event Notice</value>
+  </data>
+  <data name="SeasonEventNotice_Heading" xml:space="preserve">
+    <value>Seasonal Event</value>
+  </data>
+  <data name="SeasonEventNotice_Body" xml:space="preserve">
+    <value>It's that time of year again! There is a seasonal event happening right now!
+To join in the festivities, check out the Seasonal section in VanillaPlus!</value>
+  </data>
+  <data name="SeasonEventNotice_DailyHint" xml:space="preserve">
+    <value>This will only show once on each day a seasonal event occurs</value>
+  </data>
+  <data name="SeasonEventNotice_ButtonDismiss" xml:space="preserve">
+    <value>Go Away</value>
+  </data>
+  <data name="SeasonEventNotice_ButtonOpen" xml:space="preserve">
+    <value>Open VanillaPlus</value>
+  </data>
+  <data name="AddonConfig_AdditionalOptions" xml:space="preserve">
+    <value>Additional Options</value>
+  </data>
+  <data name="AddonConfig_DisableKeybindInCombat" xml:space="preserve">
+    <value>Disable Keybind in Combat</value>
+  </data>
 </root>

--- a/VanillaPlus/VanillaPlus.cs
+++ b/VanillaPlus/VanillaPlus.cs
@@ -38,7 +38,7 @@ public sealed class VanillaPlus : IAsyncDalamudPlugin {
 
         System.SeasonEventAddon = new SeasonEventAddon {
             InternalName = "SeasonalEventNotice",
-            Title = "Seasonal Event Notice",
+            Title = Strings.SeasonEventNotice_Title,
             Size = new Vector2(500.0f, 275.0f),
         };
 


### PR DESCRIPTION
Crowdin is in place, so only the English resx is updated here.

Updated:
* BetterTeleportWindow
* BorderlessCutscenes
* SuppressSharedBoards
* DutyPortalNameplateOffset
* Modification browser category/filter tabs + tooltips
* ModificationType.Seasonal display name
* Seasonal event notice window
* Addon keybind config options


Skipped AprilFools (experimental, meme-heavy, still contains a placeholder dev string).