### PR TITLE
Action Highlight: Fix migration + more accurate ability list

### DIFF
--- a/VanillaPlus/Extensions/ClassJobCategoryExtensions.cs
+++ b/VanillaPlus/Extensions/ClassJobCategoryExtensions.cs
@@ -7,6 +7,18 @@ public static unsafe class ClassJobCategoryExtensions {
     extension(ClassJobCategory row) {
         public Lumina.Excel.Collection<bool> ClassesJobs
             => new(row.ExcelPage, parentOffset: row.RowOffset, offset: row.RowOffset, &ClassJobCtor, size: row.ExcelPage.Module.GetSheet<ClassJob>().Count);
+
+        /// <summary>
+        /// Returns true when the provided job is supported by this ClassJob.
+        /// </summary>
+        public bool IncludesJob(ClassJob job)
+            => row.ClassesJobs[(int) job.RowId];
+
+        /// <summary>
+        /// Returns true when the provided job row id is supported by this ClassJob.
+        /// </summary>
+        public bool IncludesJob(uint classJobId)
+            => row.ClassesJobs[(int) classJobId];
     }
 
     private static bool ClassJobCtor(ExcelPage page, uint parentOffset, uint offset, uint i)

--- a/VanillaPlus/Features/ActionHighlight/ActionHighlight.cs
+++ b/VanillaPlus/Features/ActionHighlight/ActionHighlight.cs
@@ -25,7 +25,6 @@ public class ActionHighlight : GameModification {
         Type = ModificationType.UserInterface,
         Authors = ["attickdoor", "Zeffuro"],
         CompatibilityModule = new PluginCompatibilityModule("AbilityAnts"),
-        DisabledReason = "Currently unavailable.\n\nTemporarily disabled, Will return shortly. Sorry for the trouble.",
     };
 
     public override string ImageName => "ActionHighlight.png";
@@ -168,16 +167,27 @@ public class ActionHighlight : GameModification {
         }
     }
 
-    public static List<Action> GetClassActions() {
-        List<uint> additionalActions = [7444, 7445, 37018, 37023, 37024, 37025, 37026, 37027, 37028];
-
-        // I have no idea what Unknown6 is, but it's been in there since the very first AbilityAnts release.
-        // My best guess at the moment is that it removes abilities that have been replaced or upgraded.
-        return Services.DataManager.GetExcelSheet<Action>()
-            .Where(action => IsValidAction(action) || additionalActions.Contains(action.RowId))
+    public static List<Action> GetClassActions(ClassJob classJob)
+        => Services.DataManager.GetExcelSheet<Action>()
+            .Where(action => IsValidAction(action, classJob))
+            .DistinctBy(action => action.RowId)
             .ToList();
-    }
 
-    public static bool IsValidAction(Action action)
-        => action is { IsPvP: false, ClassJob.ValueNullable.Unknown6: > 0, IsPlayerAction: true } and ({ ActionCategory.RowId: 4 } or { Recast100ms: > 100 });
+    private static bool IsPlayerClassAction(Action action, ClassJob classJob)
+        => action.IsPlayerAction
+           && (action.ClassJob.RowId == classJob.RowId || action.ClassJob.RowId == classJob.ClassJobParent.RowId);
+
+    private static bool IsUnassignableClassAction(Action action, ClassJob classJob)
+        => action is { IsPlayerAction: false, ClassJob.RowId: 0, ClassJobLevel: not 0 }
+           && action.IsUsableByJob(classJob);
+
+    internal static bool IsValidAction(Action action, ClassJob classJob)
+        => action is { IsPvP: false, IsRoleAction: false }
+           && action.RowId is not (2272u or 29581u)
+           && (action.ActionCategory.RowId == 4 || action.Recast100ms > 100)
+           && (IsPlayerClassAction(action, classJob) || IsUnassignableClassAction(action, classJob));
+
+    internal static bool IsValidRoleAction(Action action, ClassJob classJob)
+        => action is { IsPvP: false, IsRoleAction: true }
+           && action.ClassJobCategory.Value.ClassesJobs[(int) classJob.RowId];
 }

--- a/VanillaPlus/Features/ActionHighlight/ActionHighlight.cs
+++ b/VanillaPlus/Features/ActionHighlight/ActionHighlight.cs
@@ -54,12 +54,14 @@ public class ActionHighlight : GameModification {
             Size = new Vector2(700.0f, 650.0f),
             InternalName = "ActionHighlightConfig",
             Title = Strings.ActionHighlight_Configuration,
-            OptionsList = Config.ClassJobConfigs,
+            OptionsList = [],
             SaveConfig = () => Task.Run(Config.Save),
             GetEntrySearchString = entry => Services.DataManager.GetExcelSheet<ClassJob>().GetRow(entry.ClassJobId).Name.ToString(),
             AddClicked = OnAddClicked,
             RemoveClicked = OnRemoveClicked,
         };
+
+        UpdateOptionsList();
 
         OpenConfigAction = configAddon.Toggle;
 
@@ -97,7 +99,7 @@ public class ActionHighlight : GameModification {
             }
 
             Task.Run(Config.Save);
-            configAddon?.OptionsList = Config.ClassJobConfigs;
+            UpdateOptionsList();
         };
 
         classJobSearchAddon?.Open();
@@ -167,25 +169,56 @@ public class ActionHighlight : GameModification {
         }
     }
 
+    private void UpdateOptionsList() {
+        if (configAddon is null) return;
+        if (Config is null) return;
+
+        Task.Run(() => {
+            var results = Config.ClassJobConfigs
+                .Where(entry => entry.ClassJobId is not 0)
+                .OrderBy(entry => Services.SeStringEvaluator.EvaluateFromAddon(981, [entry.ClassJobId]).ToString())
+                .ToList();
+
+            Services.Framework.Run(() => {
+                configAddon.OptionsList = results;
+            });
+        });
+    }
+
+    /// <summary>
+    /// Gets all valid actions for the specified ClassJob.
+    /// </summary>
     public static List<Action> GetClassActions(ClassJob classJob)
         => Services.DataManager.GetExcelSheet<Action>()
             .Where(action => IsValidAction(action, classJob))
             .DistinctBy(action => action.RowId)
             .ToList();
 
+    /// <summary>
+    /// Returns true for actions that belong to the specified ClassJob <b>or its parent class</b>.
+    /// </summary>
     private static bool IsPlayerClassAction(Action action, ClassJob classJob)
         => action.IsPlayerAction
            && (action.ClassJob.RowId == classJob.RowId || action.ClassJob.RowId == classJob.ClassJobParent.RowId);
 
+    /// <summary>
+    /// Returns true for actions that can be used, but only as flip actions from other skills, such as dancer steps.
+    /// </summary>
     private static bool IsUnassignableClassAction(Action action, ClassJob classJob)
         => action is { IsPlayerAction: false, ClassJob.RowId: 0, ClassJobLevel: not 0 }
            && action.IsUsableByJob(classJob);
 
+    /// <summary>
+    /// Returns true for actions that we want to allow ActionHighlight to highlight.
+    /// </summary>
     internal static bool IsValidAction(Action action, ClassJob classJob)
         => action is { IsPvP: false, IsRoleAction: false, RowId: not (2272u or 29581u) } // Rabbit Medium and 六道輪廻 (should be a PVP action)
            && (action.ActionCategory.RowId == 4 || action.Recast100ms > 100)
            && (IsPlayerClassAction(action, classJob) || IsUnassignableClassAction(action, classJob));
 
+    /// <summary>
+    /// Returns true for actions that are valid for the specified ClassJob.
+    /// </summary>
     internal static bool IsValidRoleAction(Action action, ClassJob classJob)
         => action is { IsPvP: false, IsRoleAction: true }
            && action.ClassJobCategory.Value.ClassesJobs[(int) classJob.RowId];

--- a/VanillaPlus/Features/ActionHighlight/ActionHighlight.cs
+++ b/VanillaPlus/Features/ActionHighlight/ActionHighlight.cs
@@ -182,8 +182,7 @@ public class ActionHighlight : GameModification {
            && action.IsUsableByJob(classJob);
 
     internal static bool IsValidAction(Action action, ClassJob classJob)
-        => action is { IsPvP: false, IsRoleAction: false }
-           && action.RowId is not (2272u or 29581u)
+        => action is { IsPvP: false, IsRoleAction: false, RowId: not (2272u or 29581u) } // Rabbit Medium and 六道輪廻 (should be a PVP action)
            && (action.ActionCategory.RowId == 4 || action.Recast100ms > 100)
            && (IsPlayerClassAction(action, classJob) || IsUnassignableClassAction(action, classJob));
 

--- a/VanillaPlus/Features/ActionHighlight/ActionHighlight.cs
+++ b/VanillaPlus/Features/ActionHighlight/ActionHighlight.cs
@@ -198,8 +198,7 @@ public class ActionHighlight : GameModification {
     /// Returns true for actions that belong to the specified ClassJob <b>or its parent class</b>.
     /// </summary>
     private static bool IsPlayerClassAction(Action action, ClassJob classJob)
-        => action.IsPlayerAction
-           && (action.ClassJob.RowId == classJob.RowId || action.ClassJob.RowId == classJob.ClassJobParent.RowId);
+        => action.IsPlayerAction && action.ClassJobCategory.Value.ClassesJobs[(int) classJob.RowId];
 
     /// <summary>
     /// Returns true for actions that can be used, but only as flip actions from other skills, such as dancer steps.
@@ -212,8 +211,8 @@ public class ActionHighlight : GameModification {
     /// Returns true for actions that we want to allow ActionHighlight to highlight.
     /// </summary>
     internal static bool IsValidAction(Action action, ClassJob classJob)
-        => action is { IsPvP: false, IsRoleAction: false, RowId: not (2272u or 29581u) } // Rabbit Medium and 六道輪廻 (should be a PVP action)
-           && (action.ActionCategory.RowId == 4 || action.Recast100ms > 100)
+        => action is { IsPvP: false, IsRoleAction: false, RowId: not (2272u or 29581u or 1584u) } // Rabbit Medium and 六道輪廻 (should be a PVP action) and Purify
+           && (action.ActionCategory.RowId == 4 || action.Recast100ms > 150)
            && (IsPlayerClassAction(action, classJob) || IsUnassignableClassAction(action, classJob));
 
     /// <summary>

--- a/VanillaPlus/Features/ActionHighlight/ActionHighlight.cs
+++ b/VanillaPlus/Features/ActionHighlight/ActionHighlight.cs
@@ -198,7 +198,7 @@ public class ActionHighlight : GameModification {
     /// Returns true for actions that belong to the specified ClassJob <b>or its parent class</b>.
     /// </summary>
     private static bool IsPlayerClassAction(Action action, ClassJob classJob)
-        => action.IsPlayerAction && action.ClassJobCategory.Value.ClassesJobs[(int) classJob.RowId];
+        => action.IsPlayerAction && action.ClassJobCategory.Value.IncludesJob(classJob);
 
     /// <summary>
     /// Returns true for actions that can be used, but only as flip actions from other skills, such as dancer steps.
@@ -220,5 +220,5 @@ public class ActionHighlight : GameModification {
     /// </summary>
     internal static bool IsValidRoleAction(Action action, ClassJob classJob)
         => action is { IsPvP: false, IsRoleAction: true }
-           && action.ClassJobCategory.Value.ClassesJobs[(int) classJob.RowId];
+           && action.ClassJobCategory.Value.IncludesJob(classJob);
 }

--- a/VanillaPlus/Features/ActionHighlight/Config/AntsConfig.cs
+++ b/VanillaPlus/Features/ActionHighlight/Config/AntsConfig.cs
@@ -46,10 +46,8 @@ public class AntsConfig : GameModificationConfig<AntsConfig> {
                     var action = Services.DataManager.GetExcelSheet<Action>().GetRow(actionId);
 
                     foreach (var classJob in classJobs) {
-                        if (!ActionHighlight.IsValidAction(action, classJob)
-                            && !ActionHighlight.IsValidRoleAction(action, classJob)) {
-                            continue;
-                        }
+                        if (!ActionHighlight.IsValidAction(action, classJob)) continue;
+                        if (!ActionHighlight.IsValidRoleAction(action, classJob)) continue;
 
                         AddActionSetting(newEntries, classJob.RowId, actionSettings, actionId);
                     }
@@ -62,15 +60,8 @@ public class AntsConfig : GameModificationConfig<AntsConfig> {
         return false;
     }
 
-    private static void AddActionSetting(
-        List<AntsClassJobConfig> entries,
-        uint classJobId,
-        AntsActionSetting source,
-        uint actionId
-    ) {
-        var entry = entries.FirstOrDefault(entry => entry.ClassJobId == classJobId);
-
-        if (entry is null) {
+    private static void AddActionSetting(List<AntsClassJobConfig> entries, uint classJobId, AntsActionSetting source, uint actionId) {
+        if (entries.FirstOrDefault(configEntry => configEntry.ClassJobId == classJobId) is not { } entry) {
             entry = new AntsClassJobConfig {
                 ClassJobId = classJobId,
                 ActionSettings = [],

--- a/VanillaPlus/Features/ActionHighlight/Config/AntsConfig.cs
+++ b/VanillaPlus/Features/ActionHighlight/Config/AntsConfig.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Lumina.Excel.Sheets;
 using Newtonsoft.Json.Linq;
 using VanillaPlus.Classes;
 using Action = Lumina.Excel.Sheets.Action;
@@ -30,6 +31,10 @@ public class AntsConfig : GameModificationConfig<AntsConfig> {
                 var actionSettingsObj = jObject["ActionSettings"]?.ToObject<JObject>();
                 if (actionSettingsObj is null) return false;
 
+                var classJobs = Services.DataManager.GetExcelSheet<ClassJob>()
+                    .Where(job => job is { RowId: not 0, Name.IsEmpty: false, IsCrafter: false, IsGatherer: false })
+                    .ToList();
+
                 List<AntsClassJobConfig> newEntries = [];
 
                 foreach (var property in actionSettingsObj.Properties()) {
@@ -38,20 +43,15 @@ public class AntsConfig : GameModificationConfig<AntsConfig> {
                     var actionSettings = property.Value.ToObject<AntsActionSetting>();
                     if (actionSettings is null) continue;
 
-                    var actionInfo = Services.DataManager.GetExcelSheet<Action>().GetRow(actionId);
+                    var action = Services.DataManager.GetExcelSheet<Action>().GetRow(actionId);
 
-                    var classJobEntry = newEntries.FirstOrDefault(entry => entry.ClassJobId == actionInfo.ClassJob.RowId);
+                    foreach (var classJob in classJobs) {
+                        if (!ActionHighlight.IsValidAction(action, classJob)
+                            && !ActionHighlight.IsValidRoleAction(action, classJob)) {
+                            continue;
+                        }
 
-                    if (classJobEntry is null) {
-                        newEntries.Add(new AntsClassJobConfig {
-                            ClassJobId = actionInfo.ClassJob.RowId,
-                            ActionSettings = [
-                                actionSettings,
-                            ],
-                        });
-                    }
-                    else {
-                        classJobEntry.ActionSettings.Add(actionSettings);
+                        AddActionSetting(newEntries, classJob.RowId, actionSettings, actionId);
                     }
                 }
 
@@ -60,5 +60,31 @@ public class AntsConfig : GameModificationConfig<AntsConfig> {
         }
 
         return false;
+    }
+
+    private static void AddActionSetting(
+        List<AntsClassJobConfig> entries,
+        uint classJobId,
+        AntsActionSetting source,
+        uint actionId
+    ) {
+        var entry = entries.FirstOrDefault(entry => entry.ClassJobId == classJobId);
+
+        if (entry is null) {
+            entry = new AntsClassJobConfig {
+                ClassJobId = classJobId,
+                ActionSettings = [],
+            };
+
+            entries.Add(entry);
+        }
+
+        if (entry.ActionSettings.Any(setting => setting.ActionId == actionId)) return;
+
+        entry.ActionSettings.Add(new AntsActionSetting {
+            ActionId = actionId,
+            IsEnabled = source.IsEnabled,
+            ThresholdMs = source.ThresholdMs,
+        });
     }
 }

--- a/VanillaPlus/Features/ActionHighlight/Config/AntsConfig.cs
+++ b/VanillaPlus/Features/ActionHighlight/Config/AntsConfig.cs
@@ -46,8 +46,7 @@ public class AntsConfig : GameModificationConfig<AntsConfig> {
                     var action = Services.DataManager.GetExcelSheet<Action>().GetRow(actionId);
 
                     foreach (var classJob in classJobs) {
-                        if (!ActionHighlight.IsValidAction(action, classJob)) continue;
-                        if (!ActionHighlight.IsValidRoleAction(action, classJob)) continue;
+                        if (!ActionHighlight.IsValidAction(action, classJob) && !ActionHighlight.IsValidRoleAction(action, classJob)) continue;
 
                         AddActionSetting(newEntries, classJob.RowId, actionSettings, actionId);
                     }

--- a/VanillaPlus/Features/ActionHighlight/Nodes/AntsClassJobConfigurationNode.cs
+++ b/VanillaPlus/Features/ActionHighlight/Nodes/AntsClassJobConfigurationNode.cs
@@ -35,21 +35,7 @@ public class AntsClassJobConfigurationNode : EntryConfigurationNode<AntsClassJob
 
         backgroundImageNode.IconId = 62000 + entry.ClassJobId;
 
-        List<Action> additionalActions = [];
-
-        // Astrologian Entries.
-        if (entry.ClassJobId is 33) {
-            foreach (var action in (List<uint>)[7444, 7445, 37018, 37023, 37024, 37025, 37026, 37027, 37028]) {
-                additionalActions.Add(Services.DataManager.GetExcelSheet<Action>().GetRow(action));
-            }
-        }
-
-        actionsListNode.OptionsList = Services.DataManager.GetExcelSheet<Action>()
-            .Where(a => !a.IsPvP && (a.ClassJob.RowId == classJob.RowId || a.ClassJob.RowId == classJob.ClassJobParent.RowId)
-                                 && a.IsPlayerAction && (a.ActionCategory.RowId == 4 || a.Recast100ms > 100) && a.RowId != 29581)
-            .Where(action => action is { IsRoleAction: false })
-            .Concat(additionalActions)
-            .ToList();
+        actionsListNode.OptionsList = ActionHighlight.GetClassActions(classJob);
 
         rolesListNode.OptionsList = Services.DataManager.GetExcelSheet<Action>()
             .Where(action => action.ClassJobCategory.Value.ClassesJobs[(int) entry.ClassJobId])

--- a/VanillaPlus/Features/ActionHighlight/Nodes/AntsClassJobConfigurationNode.cs
+++ b/VanillaPlus/Features/ActionHighlight/Nodes/AntsClassJobConfigurationNode.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 using KamiToolKit.Components.ConfigurationNodes;


### PR DESCRIPTION
Config used for testing migration: 
[OLD_ActionHighlightConfig.config.json](https://github.com/user-attachments/files/29106488/OLD_ActionHighlightConfig.config.json)

https://github.com/user-attachments/assets/e2891f55-654a-449b-bd1b-ed786dd9c350

Also checked IDA to see how the game does it so it should be a lot more closer so we don't need the hardcoded AST abilities anymore (I did have to make 2 exclusions, both for NIN). The interesting sub in case you want to investigate more is sub_140EEC010