### PR TITLE
Use new AddonCastBarEnemy

### DIFF
--- a/VanillaPlus/Features/TargetCastBarCountdown/NameplateCastbarController.cs
+++ b/VanillaPlus/Features/TargetCastBarCountdown/NameplateCastbarController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Numerics;
 using System.Threading.Tasks;
@@ -8,6 +8,8 @@ using KamiToolKit.Controllers;
 using KamiToolKit.Nodes;
 using VanillaPlus.Classes;
 using VanillaPlus.Utilities;
+
+using NewAddonCastBarEnemy = FFXIVClientStructs.FFXIV.Client.UI.AddonCastBarEnemy;
 
 namespace VanillaPlus.Features.TargetCastBarCountdown;
 
@@ -19,7 +21,7 @@ public class NameplateCastbarController : IDisposable {
 
     private const string StylePath = "TargetCastBarCountdown.CastBarEnemy.style.json";
 
-    private readonly AddonController<AddonCastBarEnemy> addonController;
+    private readonly AddonController<NewAddonCastBarEnemy> addonController;
 
     public unsafe NameplateCastbarController(TargetCastBarCountdownConfig config) {
         this.config = config;
@@ -46,7 +48,7 @@ public class NameplateCastbarController : IDisposable {
             }
         };
 
-        addonController = new AddonController<AddonCastBarEnemy> {
+        addonController = new AddonController<NewAddonCastBarEnemy> {
             AddonName = "CastBarEnemy",
             OnSetup = OnAddonSetup,
             OnFinalize = OnAddonFinalize,
@@ -62,7 +64,7 @@ public class NameplateCastbarController : IDisposable {
         addonController.Dispose();
     }
 
-    private unsafe void OnAddonSetup(AddonCastBarEnemy* addonCastBarEnemy) {
+    private unsafe void OnAddonSetup(NewAddonCastBarEnemy* addonCastBarEnemy) {
         textNodes = new TextNode[10];
 
         foreach (var index in Enumerable.Range(0, 10)) {
@@ -87,7 +89,7 @@ public class NameplateCastbarController : IDisposable {
         }
     }
 
-    private unsafe void OnAddonRefresh(AddonCastBarEnemy* addonCastBarEnemy) {
+    private unsafe void OnAddonRefresh(NewAddonCastBarEnemy* addonCastBarEnemy) {
         if (Services.ClientState.IsPvP || !config.PrimaryTarget) {
             foreach (var node in textNodes ?? []) {
                 node.String = string.Empty;
@@ -97,13 +99,13 @@ public class NameplateCastbarController : IDisposable {
 
         foreach (var index in Enumerable.Range(0, 10)) {
             var info = addonCastBarEnemy->CastBarInfo[index];
-            var battleChara = Services.ObjectTable.GetBattleChara(info.ObjectId.ObjectId);
+            var battleChara = Services.ObjectTable.GetBattleChara(info.EntityId);
 
             textNodes?[index].String = battleChara?.GetCastTimeString;
         }
     }
 
-    private unsafe void OnAddonFinalize(AddonCastBarEnemy* addonCastBarEnemy) {
+    private unsafe void OnAddonFinalize(NewAddonCastBarEnemy* addonCastBarEnemy) {
         foreach (var node in textNodes ?? []) {
             node.Dispose();
         }


### PR DESCRIPTION
The [old one](https://github.com/aers/FFXIVClientStructs/blob/main/FFXIVClientStructs/FFXIV/Client/UI/AddonCastBarEnemy-NoNamespace.cs) was not in a namespace, so we have to do the `using` trick to get the [new one](https://github.com/aers/FFXIVClientStructs/blob/main/FFXIVClientStructs/FFXIV/Client/UI/AddonCastBarEnemy.cs), because the old one is global...

**Don't merge just yet. It requires a Dalamud release for the new CS update.**
This is mainly for building locally if you're on stg right now.