### PR TITLE
Add game config command

### DIFF
--- a/VanillaPlus.sln.DotSettings
+++ b/VanillaPlus.sln.DotSettings
@@ -9,6 +9,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=dalamud_0027s/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Eorzea/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Epinephren/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=gameconfig/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=guildhest/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=guildhests/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=hasel/@EntryIndexedValue">True</s:Boolean>

--- a/VanillaPlus/Features/BetterTeleportWindow/TeleportAddon.cs
+++ b/VanillaPlus/Features/BetterTeleportWindow/TeleportAddon.cs
@@ -95,7 +95,6 @@ public class TeleportAddon(BetterTeleportWindowConfig config) : NativeAddon {
                             Height = ContentSize.Y - 28.0f - itemSpacing * 2.0f,
                             ItemSpacing = itemSpacing * 1.5f,
                             OptionsList = IAetheryteList.Get().ToList(),
-                            NoResultsString = Strings.BetterTeleportWindow_NoResults,
                         },
                     ],
                 },

--- a/VanillaPlus/Features/GameConfigCommand/ConfigSection.cs
+++ b/VanillaPlus/Features/GameConfigCommand/ConfigSection.cs
@@ -1,0 +1,10 @@
+﻿namespace VanillaPlus.Features.GameConfigCommand;
+
+/// <summary>
+/// Enumeration used to differentiate different sections of IGameConfig
+/// </summary>
+public enum ConfigSection {
+    System,
+    UiConfig,
+    UiControl,
+}

--- a/VanillaPlus/Features/GameConfigCommand/GameConfigCommand.cs
+++ b/VanillaPlus/Features/GameConfigCommand/GameConfigCommand.cs
@@ -1,15 +1,12 @@
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
-using System.Reflection;
 using System.Threading.Tasks;
 using Dalamud.Game.Command;
 using Dalamud.Game.Config;
 using Dalamud.Plugin.Services;
 using VanillaPlus.Classes;
 using VanillaPlus.Enums;
-using VanillaPlus.Extensions;
 
 namespace VanillaPlus.Features.GameConfigCommand;
 
@@ -18,194 +15,148 @@ public class GameConfigCommand : GameModification {
         DisplayName = Strings.ModificationDisplay_GameConfigCommand,
         Description = Strings.ModificationDescription_GameConfigCommand,
         Type = ModificationType.GameBehavior,
-        Authors = ["Ren"],
+        Authors = [ "Ren" ],
     };
 
-    private const string CommandName = "/gameconfig";
-    private const string Usage = "Usage: /gameconfig <system|ui|control> <option> <value>";
-
-    private static readonly ConfigOption[] ConfigOptions = [
-        .. GetConfigOptions<SystemConfigOption>(ConfigSection.System),
-        .. GetConfigOptions<UiConfigOption>(ConfigSection.UiConfig),
-        .. GetConfigOptions<UiControlOption>(ConfigSection.UiControl),
-    ];
+    private static Dictionary<ConfigSection, Dictionary<string, GameConfigOptionAttribute>>? configMapping;
 
     public override Task OnEnableAsync() {
-        ICommandManager.Get().AddHandler(CommandName, new CommandInfo(OnCommand) {
-            HelpMessage = Usage,
+        ICommandManager.Get().AddHandler("/gameconfig", new CommandInfo(OnCommand) {
+            HelpMessage = "Usage: /gameconfig <system|ui|control> <option> <value>",
             ShowInHelp = true,
         });
+
+        configMapping = new Dictionary<ConfigSection, Dictionary<string, GameConfigOptionAttribute>> {
+            [ConfigSection.System] =
+                Enum.GetValues<SystemConfigOption>()
+                    .Select(option => option.GetAttribute<GameConfigOptionAttribute>())
+                    .OfType<GameConfigOptionAttribute>()
+                    .ToDictionary(key => key.Name.ToLowerInvariant(), value => value),
+
+            [ConfigSection.UiConfig] =
+                Enum.GetValues<UiConfigOption>()
+                    .Select(option => option.GetAttribute<GameConfigOptionAttribute>())
+                    .OfType<GameConfigOptionAttribute>()
+                    .ToDictionary(key => key.Name.ToLowerInvariant(), value => value),
+
+            [ConfigSection.UiControl] =
+                Enum.GetValues<UiControlOption>()
+                    .Select(option => option.GetAttribute<GameConfigOptionAttribute>())
+                    .OfType<GameConfigOptionAttribute>()
+                    .ToDictionary(key => key.Name.ToLowerInvariant(), value => value),
+        };
 
         return Task.CompletedTask;
     }
 
     public override Task OnDisableAsync() {
-        ICommandManager.Get().RemoveHandler(CommandName);
+        ICommandManager.Get().RemoveHandler("/gameconfig");
+
+        configMapping = null;
 
         return Task.CompletedTask;
     }
 
     private static void OnCommand(string command, string arguments) {
-        var remainingArguments = arguments.Trim();
-        var sectionName = TakeArgument(ref remainingArguments);
-
-        if (!TryParseSection(sectionName, out var section)) {
-            IChatGui.Get().PrintError(Usage);
-            return;
-        }
-
-        var optionName = TakeArgument(ref remainingArguments);
-
-        if (optionName.Length is 0 || remainingArguments.Length is 0) {
-            IChatGui.Get().PrintError(Usage);
-            return;
-        }
-
-        var configOption = ConfigOptions.FirstOrDefault(option => option.Section == section
-            && (option.Name.Equals(optionName, StringComparison.OrdinalIgnoreCase)
-                || option.EnumName.Equals(optionName, StringComparison.OrdinalIgnoreCase)));
-
-        if (configOption is null) {
-            IChatGui.Get().PrintError($"Unknown {GetSectionArgument(section)} configuration option: {optionName}");
-            return;
-        }
-
-        if (!configOption.Settable) {
-            IChatGui.Get().PrintError($"{configOption.Name} cannot be changed while the game is running.");
-            return;
-        }
+        if (command is not "/gameconfig") return;
 
         if (ICondition.Get().IsInCombat) {
-            IChatGui.Get().PrintError("Game configuration cannot be changed while in combat.");
+            IChatGui.Get().PrintError("Game configuration cannot be changed while in combat.", "VanillaPlus");
             return;
         }
 
-        try {
-            SetValue(configOption, remainingArguments);
-        }
-        catch (Exception exception) {
-            IPluginLog.Get().Error(exception, $"Failed to update {configOption.Section}.{configOption.Name}");
-            IChatGui.Get().PrintError($"Failed to update {configOption.Name}.");
-        }
-    }
-
-    private static void SetValue(ConfigOption option, string valueText) {
-        var section = GetConfigSection(option.Section);
-
-        switch (option.Type) {
-            case ConfigType.UInt:
-                if (!uint.TryParse(valueText, NumberStyles.Integer, CultureInfo.InvariantCulture, out var uintValue)) {
-                    IChatGui.Get().PrintError($"{option.Name} requires an unsigned integer value.");
-                    return;
+        switch (arguments.ToLowerInvariant().Split(' ')) {
+            case ["system", { Length: > 0 } option, { Length: > 0 } value]: {
+                if (configMapping?[ConfigSection.System].TryGetValue(option.ToLowerInvariant(), out var optionAttribute) ?? false) {
+                    SetConfigOption(ConfigSection.System, optionAttribute, value);
                 }
-
-                if (section.TryGetProperties(option.Name, out UIntConfigProperties? uintProperties)
-                    && uintProperties is not null
-                    && (uintValue < uintProperties.Minimum || uintValue > uintProperties.Maximum)) {
-                    IChatGui.Get().PrintError($"{option.Name} must be between {uintProperties.Minimum} and {uintProperties.Maximum}.");
-                    return;
-                }
-
-                section.Set(option.Name, uintValue);
                 break;
+            }
 
-            case ConfigType.Float:
-                if (!float.TryParse(valueText, NumberStyles.Float, CultureInfo.InvariantCulture, out var floatValue)
-                    || !float.IsFinite(floatValue)) {
-                    IChatGui.Get().PrintError($"{option.Name} requires a decimal value.");
-                    return;
+            case ["ui", { Length: > 0 } option, { Length: > 0 } value]: {
+                if (configMapping?[ConfigSection.UiConfig].TryGetValue(option.ToLowerInvariant(), out var optionAttribute) ?? false) {
+                    SetConfigOption(ConfigSection.UiConfig, optionAttribute, value);
                 }
+                break;
+            }
 
-                if (section.TryGetProperties(option.Name, out FloatConfigProperties? floatProperties)
-                    && floatProperties is not null
-                    && (floatValue < floatProperties.Minimum || floatValue > floatProperties.Maximum)) {
-                    IChatGui.Get().PrintError($"{option.Name} must be between {floatProperties.Minimum} and {floatProperties.Maximum}.");
-                    return;
+            case ["control", { Length: > 0 } option, { Length: > 0 } value]: {
+                if (configMapping?[ConfigSection.UiControl].TryGetValue(option.ToLowerInvariant(), out var optionAttribute) ?? false) {
+                    SetConfigOption(ConfigSection.UiControl, optionAttribute, value);
                 }
-
-                section.Set(option.Name, floatValue);
                 break;
-
-            case ConfigType.String:
-                section.Set(option.Name, valueText);
-                break;
+            }
 
             default:
-                IChatGui.Get().PrintError($"{option.Name} uses an unsupported configuration type.");
-                return;
+                IChatGui.Get().PrintError(
+                    $"Error processing command for {command} {arguments}, check the arguments and try again.\n" +
+                    $"Usage: /gameconfig <system|ui|control> <option> <value>", "VanillaPlus"
+                );
+                break;
         }
-
-        IChatGui.Get().Print($"Updated {GetSectionArgument(option.Section)}.{option.Name}.");
     }
 
-    private static GameConfigSection GetConfigSection(ConfigSection section) => section switch {
-        ConfigSection.System => IGameConfig.Get().System,
-        ConfigSection.UiConfig => IGameConfig.Get().UiConfig,
-        ConfigSection.UiControl => IGameConfig.Get().UiControl,
-        _ => throw new ArgumentOutOfRangeException(nameof(section), section, null),
-    };
+    private static void SetConfigOption(ConfigSection section, GameConfigOptionAttribute option, string valueString) {
+        if (option is { Settable: false }) {
+            IChatGui.Get().PrintError($"Config option {option.Name} is not allowed to be set.", "VanillaPlus");
+            return;
+        }
 
-    private static IEnumerable<ConfigOption> GetConfigOptions<TEnum>(ConfigSection section) where TEnum : struct, Enum {
-        foreach (var option in Enum.GetValues<TEnum>()) {
-            var enumName = option.ToString();
-            var attribute = typeof(TEnum).GetField(enumName)?.GetCustomAttribute<GameConfigOptionAttribute>();
+        var configSection = section switch {
+            ConfigSection.System => IGameConfig.Get().System,
+            ConfigSection.UiConfig => IGameConfig.Get().UiConfig,
+            ConfigSection.UiControl => IGameConfig.Get().UiControl,
+            _ => null,
+        };
 
-            if (attribute is not null) {
-                yield return new ConfigOption(section, enumName, attribute.Name, attribute.Type, attribute.Settable);
+        if (configSection is null) return;
+
+        try {
+            switch (option) {
+                case { Type: ConfigType.UInt, Name: var name } when uint.TryParse(valueString, out var uintValue):
+
+                    if (configSection.TryGetProperties(name, out UIntConfigProperties? uintProperties) && uintProperties is not null) {
+                        if (uintValue < uintProperties.Minimum || uintValue > uintProperties.Maximum) {
+                            IChatGui.Get().PrintError($"Argument for {option.Name} must be between {uintProperties.Minimum} and {uintProperties.Maximum}.", "VanillaPlus");
+                            return;
+                        }
+                    }
+
+                    configSection.Set(name, uintValue);
+                    IChatGui.Get().Print($"Updated {section.Description}.{option.Name}.");
+                    return;
+
+                case { Type: ConfigType.Float, Name: var name } when float.TryParse(valueString, out var floatValue):
+
+                    if (!float.IsFinite(floatValue)) {
+                        IChatGui.Get().PrintError($"{option.Name} requires a decimal value.", "VanillaPlus");
+                        return;
+                    }
+
+                    if (configSection.TryGetProperties(name, out FloatConfigProperties? floatProperties) && floatProperties is not null) {
+                        if (floatValue < floatProperties.Minimum || floatValue > floatProperties.Maximum) {
+                            IChatGui.Get().PrintError($"{option.Name} must be between {floatProperties.Minimum} and {floatProperties.Maximum}.", "VanillaPlus");
+                            return;
+                        }
+                    }
+
+                    configSection.Set(name, floatValue);
+                    IChatGui.Get().Print($"Updated {section.Description}.{option.Name}.");
+                    return;
+
+                case { Type: ConfigType.String, Name: var name }:
+                    configSection.Set(name, valueString);
+                    IChatGui.Get().Print($"Updated {section.Description}.{option.Name}.");
+                    return;
+
+                default:
+                    IChatGui.Get().PrintError($"Error processing command for {option.Name}, check the arguments and try again.", "VanillaPlus");
+                    return;
             }
         }
-    }
-
-    private static string TakeArgument(ref string arguments) {
-        arguments = arguments.TrimStart();
-
-        var separatorIndex = arguments.IndexOf(' ');
-        if (separatorIndex is -1) {
-            var argument = arguments;
-            arguments = string.Empty;
-            return argument;
-        }
-
-        var result = arguments[..separatorIndex];
-        arguments = arguments[(separatorIndex + 1)..].TrimStart();
-        return result;
-    }
-
-    private static bool TryParseSection(string argument, out ConfigSection section) {
-        switch (argument.ToLowerInvariant()) {
-            case "system":
-                section = ConfigSection.System;
-                return true;
-            case "ui":
-                section = ConfigSection.UiConfig;
-                return true;
-            case "control":
-                section = ConfigSection.UiControl;
-                return true;
-            default:
-                section = default;
-                return false;
+        catch (Exception e) {
+            IChatGui.Get().PrintError($"Error processing command for {option.Name}, check the arguments and try again.", "VanillaPlus");
+            IPluginLog.Get().Exception(e);
         }
     }
-
-    private static string GetSectionArgument(ConfigSection section) => section switch {
-        ConfigSection.System => "system",
-        ConfigSection.UiConfig => "ui",
-        ConfigSection.UiControl => "control",
-        _ => throw new ArgumentOutOfRangeException(nameof(section), section, null),
-    };
-
-    private enum ConfigSection {
-        System,
-        UiConfig,
-        UiControl,
-    }
-
-    private sealed record ConfigOption(
-        ConfigSection Section,
-        string EnumName,
-        string Name,
-        ConfigType Type,
-        bool Settable
-    );
 }

--- a/VanillaPlus/Features/GameConfigCommand/GameConfigCommand.cs
+++ b/VanillaPlus/Features/GameConfigCommand/GameConfigCommand.cs
@@ -22,7 +22,7 @@ public class GameConfigCommand : GameModification {
     };
 
     private const string CommandName = "/gameconfig";
-    private const string Usage = "Usage: /gameconfig [system|ui|control] <option> <value>";
+    private const string Usage = "Usage: /gameconfig <system|ui|control> <option> <value>";
 
     private static readonly ConfigOption[] ConfigOptions = [
         .. GetConfigOptions<SystemConfigOption>(ConfigSection.System),
@@ -47,37 +47,28 @@ public class GameConfigCommand : GameModification {
 
     private static void OnCommand(string command, string arguments) {
         var remainingArguments = arguments.Trim();
-        var optionName = TakeArgument(ref remainingArguments);
-        ConfigSection? requestedSection = null;
+        var sectionName = TakeArgument(ref remainingArguments);
 
-        if (TryParseSection(optionName, out var section)) {
-            requestedSection = section;
-            optionName = TakeArgument(ref remainingArguments);
+        if (!TryParseSection(sectionName, out var section)) {
+            IChatGui.Get().PrintError(Usage);
+            return;
         }
+
+        var optionName = TakeArgument(ref remainingArguments);
 
         if (optionName.Length is 0 || remainingArguments.Length is 0) {
             IChatGui.Get().PrintError(Usage);
             return;
         }
 
-        var matches = ConfigOptions
-            .Where(option => requestedSection is null || option.Section == requestedSection)
-            .Where(option => option.Name.Equals(optionName, StringComparison.OrdinalIgnoreCase)
-                || option.EnumName.Equals(optionName, StringComparison.OrdinalIgnoreCase))
-            .ToList();
+        var configOption = ConfigOptions.FirstOrDefault(option => option.Section == section
+            && (option.Name.Equals(optionName, StringComparison.OrdinalIgnoreCase)
+                || option.EnumName.Equals(optionName, StringComparison.OrdinalIgnoreCase)));
 
-        if (matches.Count is 0) {
-            IChatGui.Get().PrintError($"Unknown game configuration option: {optionName}");
+        if (configOption is null) {
+            IChatGui.Get().PrintError($"Unknown {GetSectionArgument(section)} configuration option: {optionName}");
             return;
         }
-
-        if (matches.Count > 1) {
-            var sections = string.Join(", ", matches.Select(option => GetSectionArgument(option.Section)));
-            IChatGui.Get().PrintError($"{optionName} exists in multiple sections ({sections}). Specify a section.");
-            return;
-        }
-
-        var configOption = matches[0];
 
         if (!configOption.Settable) {
             IChatGui.Get().PrintError($"{configOption.Name} cannot be changed while the game is running.");

--- a/VanillaPlus/Features/GameConfigCommand/GameConfigCommand.cs
+++ b/VanillaPlus/Features/GameConfigCommand/GameConfigCommand.cs
@@ -1,0 +1,220 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Dalamud.Game.Command;
+using Dalamud.Game.Config;
+using Dalamud.Plugin.Services;
+using VanillaPlus.Classes;
+using VanillaPlus.Enums;
+using VanillaPlus.Extensions;
+
+namespace VanillaPlus.Features.GameConfigCommand;
+
+public class GameConfigCommand : GameModification {
+    public override ModificationInfo ModificationInfo => new() {
+        DisplayName = Strings.ModificationDisplay_GameConfigCommand,
+        Description = Strings.ModificationDescription_GameConfigCommand,
+        Type = ModificationType.GameBehavior,
+        Authors = ["Ren"],
+    };
+
+    private const string CommandName = "/gameconfig";
+    private const string Usage = "Usage: /gameconfig [system|ui|control] <option> <value>";
+
+    private static readonly ConfigOption[] ConfigOptions = [
+        .. GetConfigOptions<SystemConfigOption>(ConfigSection.System),
+        .. GetConfigOptions<UiConfigOption>(ConfigSection.UiConfig),
+        .. GetConfigOptions<UiControlOption>(ConfigSection.UiControl),
+    ];
+
+    public override Task OnEnableAsync() {
+        ICommandManager.Get().AddHandler(CommandName, new CommandInfo(OnCommand) {
+            HelpMessage = Usage,
+            ShowInHelp = true,
+        });
+
+        return Task.CompletedTask;
+    }
+
+    public override Task OnDisableAsync() {
+        ICommandManager.Get().RemoveHandler(CommandName);
+
+        return Task.CompletedTask;
+    }
+
+    private static void OnCommand(string command, string arguments) {
+        var remainingArguments = arguments.Trim();
+        var optionName = TakeArgument(ref remainingArguments);
+        ConfigSection? requestedSection = null;
+
+        if (TryParseSection(optionName, out var section)) {
+            requestedSection = section;
+            optionName = TakeArgument(ref remainingArguments);
+        }
+
+        if (optionName.Length is 0 || remainingArguments.Length is 0) {
+            IChatGui.Get().PrintError(Usage);
+            return;
+        }
+
+        var matches = ConfigOptions
+            .Where(option => requestedSection is null || option.Section == requestedSection)
+            .Where(option => option.Name.Equals(optionName, StringComparison.OrdinalIgnoreCase)
+                || option.EnumName.Equals(optionName, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        if (matches.Count is 0) {
+            IChatGui.Get().PrintError($"Unknown game configuration option: {optionName}");
+            return;
+        }
+
+        if (matches.Count > 1) {
+            var sections = string.Join(", ", matches.Select(option => GetSectionArgument(option.Section)));
+            IChatGui.Get().PrintError($"{optionName} exists in multiple sections ({sections}). Specify a section.");
+            return;
+        }
+
+        var configOption = matches[0];
+
+        if (!configOption.Settable) {
+            IChatGui.Get().PrintError($"{configOption.Name} cannot be changed while the game is running.");
+            return;
+        }
+
+        if (ICondition.Get().IsInCombat) {
+            IChatGui.Get().PrintError("Game configuration cannot be changed while in combat.");
+            return;
+        }
+
+        try {
+            SetValue(configOption, remainingArguments);
+        }
+        catch (Exception exception) {
+            IPluginLog.Get().Error(exception, $"Failed to update {configOption.Section}.{configOption.Name}");
+            IChatGui.Get().PrintError($"Failed to update {configOption.Name}.");
+        }
+    }
+
+    private static void SetValue(ConfigOption option, string valueText) {
+        var section = GetConfigSection(option.Section);
+
+        switch (option.Type) {
+            case ConfigType.UInt:
+                if (!uint.TryParse(valueText, NumberStyles.Integer, CultureInfo.InvariantCulture, out var uintValue)) {
+                    IChatGui.Get().PrintError($"{option.Name} requires an unsigned integer value.");
+                    return;
+                }
+
+                if (section.TryGetProperties(option.Name, out UIntConfigProperties? uintProperties)
+                    && uintProperties is not null
+                    && (uintValue < uintProperties.Minimum || uintValue > uintProperties.Maximum)) {
+                    IChatGui.Get().PrintError($"{option.Name} must be between {uintProperties.Minimum} and {uintProperties.Maximum}.");
+                    return;
+                }
+
+                section.Set(option.Name, uintValue);
+                break;
+
+            case ConfigType.Float:
+                if (!float.TryParse(valueText, NumberStyles.Float, CultureInfo.InvariantCulture, out var floatValue)
+                    || !float.IsFinite(floatValue)) {
+                    IChatGui.Get().PrintError($"{option.Name} requires a decimal value.");
+                    return;
+                }
+
+                if (section.TryGetProperties(option.Name, out FloatConfigProperties? floatProperties)
+                    && floatProperties is not null
+                    && (floatValue < floatProperties.Minimum || floatValue > floatProperties.Maximum)) {
+                    IChatGui.Get().PrintError($"{option.Name} must be between {floatProperties.Minimum} and {floatProperties.Maximum}.");
+                    return;
+                }
+
+                section.Set(option.Name, floatValue);
+                break;
+
+            case ConfigType.String:
+                section.Set(option.Name, valueText);
+                break;
+
+            default:
+                IChatGui.Get().PrintError($"{option.Name} uses an unsupported configuration type.");
+                return;
+        }
+
+        IChatGui.Get().Print($"Updated {GetSectionArgument(option.Section)}.{option.Name}.");
+    }
+
+    private static GameConfigSection GetConfigSection(ConfigSection section) => section switch {
+        ConfigSection.System => IGameConfig.Get().System,
+        ConfigSection.UiConfig => IGameConfig.Get().UiConfig,
+        ConfigSection.UiControl => IGameConfig.Get().UiControl,
+        _ => throw new ArgumentOutOfRangeException(nameof(section), section, null),
+    };
+
+    private static IEnumerable<ConfigOption> GetConfigOptions<TEnum>(ConfigSection section) where TEnum : struct, Enum {
+        foreach (var option in Enum.GetValues<TEnum>()) {
+            var enumName = option.ToString();
+            var attribute = typeof(TEnum).GetField(enumName)?.GetCustomAttribute<GameConfigOptionAttribute>();
+
+            if (attribute is not null) {
+                yield return new ConfigOption(section, enumName, attribute.Name, attribute.Type, attribute.Settable);
+            }
+        }
+    }
+
+    private static string TakeArgument(ref string arguments) {
+        arguments = arguments.TrimStart();
+
+        var separatorIndex = arguments.IndexOf(' ');
+        if (separatorIndex is -1) {
+            var argument = arguments;
+            arguments = string.Empty;
+            return argument;
+        }
+
+        var result = arguments[..separatorIndex];
+        arguments = arguments[(separatorIndex + 1)..].TrimStart();
+        return result;
+    }
+
+    private static bool TryParseSection(string argument, out ConfigSection section) {
+        switch (argument.ToLowerInvariant()) {
+            case "system":
+                section = ConfigSection.System;
+                return true;
+            case "ui":
+                section = ConfigSection.UiConfig;
+                return true;
+            case "control":
+                section = ConfigSection.UiControl;
+                return true;
+            default:
+                section = default;
+                return false;
+        }
+    }
+
+    private static string GetSectionArgument(ConfigSection section) => section switch {
+        ConfigSection.System => "system",
+        ConfigSection.UiConfig => "ui",
+        ConfigSection.UiControl => "control",
+        _ => throw new ArgumentOutOfRangeException(nameof(section), section, null),
+    };
+
+    private enum ConfigSection {
+        System,
+        UiConfig,
+        UiControl,
+    }
+
+    private sealed record ConfigOption(
+        ConfigSection Section,
+        string EnumName,
+        string Name,
+        ConfigType Type,
+        bool Settable
+    );
+}

--- a/VanillaPlus/Features/OpenGlamourDresserToCurrentJob/OpenGlamourDresserToCurrentJob.cs
+++ b/VanillaPlus/Features/OpenGlamourDresserToCurrentJob/OpenGlamourDresserToCurrentJob.cs
@@ -1,8 +1,8 @@
-﻿using System.Runtime.InteropServices;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Dalamud.Game.Addon.Lifecycle;
 using Dalamud.Game.Addon.Lifecycle.AddonArgTypes;
 using Dalamud.Plugin.Services;
+using FFXIVClientStructs.FFXIV.Client.UI;
 using VanillaPlus.Classes;
 using VanillaPlus.Enums;
 
@@ -29,9 +29,10 @@ public class OpenGlamourDresserToCurrentJob : GameModification {
         return Task.CompletedTask;
     }
 
-    private void OnGlamourDresserSetup(AddonEvent type, AddonArgs args) {
+    private unsafe void OnGlamourDresserSetup(AddonEvent type, AddonArgs args) {
         if (IObjectTable.Get() is { LocalPlayer.ClassJob.RowId: var playerJob }) {
-            Marshal.WriteByte(args.Addon, 0x1A8, (byte)playerJob);
+            var addon = args.GetAddon<AddonMiragePrismPrismBox>();
+            addon->Param = (int) playerJob;
         }
     }
 }

--- a/VanillaPlus/Native/Addons/ModificationBrowserAddon.cs
+++ b/VanillaPlus/Native/Addons/ModificationBrowserAddon.cs
@@ -101,7 +101,6 @@ public class ModificationBrowserAddon : NativeAddon {
                                     NavUp = 6,
                                     NavRight = 100,
                                     OptionsList = GetModifications(),
-                                    NoResultsString = Strings.ModificationBrowser_NoResults,
                                     OnItemSelected = selectedItem
                                         => modificationInfoNode?.SetDisplayedGameModification(selectedItem),
                                 },

--- a/VanillaPlus/Resources/Strings.Designer.cs
+++ b/VanillaPlus/Resources/Strings.Designer.cs
@@ -2503,7 +2503,7 @@ namespace Resources {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to Adds a text command for changing game configuration options..
+        ///   Looks up a localized string similar to Adds the /gameconfig command for changing game configuration options..
         /// </summary>
         internal static string ModificationDescription_GameConfigCommand {
             get {

--- a/VanillaPlus/Resources/Strings.Designer.cs
+++ b/VanillaPlus/Resources/Strings.Designer.cs
@@ -2501,7 +2501,16 @@ namespace Resources {
                 return ResourceManager.GetString("ModificationDescription_ForcedCutsceneSounds", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Adds a text command for changing game configuration options..
+        /// </summary>
+        internal static string ModificationDescription_GameConfigCommand {
+            get {
+                return ResourceManager.GetString("ModificationDescription_GameConfigCommand", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to When equipping gearsets, set alternative sets to load depending on what zone you are in..
         /// </summary>
@@ -3222,7 +3231,16 @@ namespace Resources {
                 return ResourceManager.GetString("ModificationDisplay_ForcedCutsceneSounds", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Game Config Command.
+        /// </summary>
+        internal static string ModificationDisplay_GameConfigCommand {
+            get {
+                return ResourceManager.GetString("ModificationDisplay_GameConfigCommand", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Gearset Redirect.
         /// </summary>

--- a/VanillaPlus/Resources/Strings.resx
+++ b/VanillaPlus/Resources/Strings.resx
@@ -1719,6 +1719,6 @@ To join in the festivities, check out the Seasonal section in VanillaPlus!</valu
     <value>Game Config Command</value>
   </data>
   <data name="ModificationDescription_GameConfigCommand" xml:space="preserve">
-    <value>Adds a text command for changing game configuration options.</value>
+    <value>Adds the /gameconfig command for changing game configuration options.</value>
   </data>
 </root>

--- a/VanillaPlus/Resources/Strings.resx
+++ b/VanillaPlus/Resources/Strings.resx
@@ -1715,4 +1715,10 @@ To join in the festivities, check out the Seasonal section in VanillaPlus!</valu
   <data name="ModificationDescription_ZoneTransitionLabels" xml:space="preserve">
       <value>Adds labels to zone lines to indicate where they lead. Designed to look like FFXII.</value>
   </data>
+  <data name="ModificationDisplay_GameConfigCommand" xml:space="preserve">
+    <value>Game Config Command</value>
+  </data>
+  <data name="ModificationDescription_GameConfigCommand" xml:space="preserve">
+    <value>Adds a text command for changing game configuration options.</value>
+  </data>
 </root>


### PR DESCRIPTION
Adds a Game Config Command modification that exposes Dalamud's enum-backed game configuration options through a single `/gameconfig` command.


/gameconfig PartyListNameType 3
/gameconfig LogNameType 3

I allowed a section to be specified when an option exists in more than one place:

/gameconfig ui PadMode 1
/gameconfig system PadMode 1

I added System, UiConfig, and UiControl options. Values are parsed according to each option's GameConfigOptionAttribute, including UInt, Float, and String values.

Writes are rejected when:

- The player is in combat.
- The option is not settable.
- The value has the wrong type.
- A numeric value is outside the option's reported range.
- The option name is unknown or ambiguous.

## Testing

- Loaded and tested in-game as a development plugin.
- Verified PartyListNameType and LogNameType changes.
- Verified invalid values, ambiguous options, and combat restrictions.

## Examples

```
/gameconfig PartyListNameType 3
/gameconfig LogNameType 3

/gameconfig control PartyListNameType 0
/gameconfig ui LogNameType 0

```

<img width="334" height="246" alt="image" src="https://github.com/user-attachments/assets/e86eb560-abab-4e3e-afab-4f20f157a6b8" />


Note:
my c# is rusty, i followed conventions where i saw, please feel free to edit,give advice, etc